### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@
   </a>
 </p>
 
-This library is a modern, pure Go readline implementation, enhanced with editing and user 
-interface features commonly found in modern shells, all in little more than 10K lines of code.
-Its kemap-based model and completion engine is heavily inspired from the Z-Shell architecture.
+This library is a modern, pure Go `readline` shell implementation, with full `.inputrc` and legacy
+readline command/option support, and extended with various commands,options and tools commonly
+found in more modern shells. Its architecture and completion system is heavily inspired from Z-Shell.
 It is used, between others, to power the [console](https://github.com/reeflective/console) library.
 
 
@@ -51,14 +51,14 @@ It is used, between others, to power the [console](https://github.com/reeflectiv
 - Full `.inputrc` support (all commands/options)
 - Extensive test suite and full coverage of core code
 - [Extended list](https://github.com/reeflective/readline/wiki/Keymaps-&-Widgets) of additional commands/options (edition/completion/history)
-- Complete multiline edition/movement support
+- Complete [multiline edition/movement support](https://github.com/reeflective/readline/wiki/Multiline)
 - Command-line edition in `$EDITOR`/`$VISUAL` support
 - Programmable API, with failure-safe access to core components
-- Support for an arbitrary number of history sources
+- Support for an [arbitrary number of history sources](https://github.com/reeflective/readline/wiki/History-Sources)
 
 ### Emacs / Standard
 - Native Emacs commands
-- Emacs-style macro engine (not working accross multiple calls)
+- Emacs-style [macro engine](https://github.com/reeflective/readline/wiki/Macros#emacs) (not working accross multiple calls)
 - Keywords switching (operators, booleans, hex/binary/digit) with iterations
 - Command/mode cursor status indicator
 - Complete undo/redo history
@@ -71,16 +71,16 @@ It is used, between others, to power the [console](https://github.com/reeflectiv
 - Vim Visual/Operator pending mode & cursor styles indications
 - Vim Insert and Replace (once/many)
 - All Vim registers, with completion support
-- Vim-style macro recording (`q<a>`) and invocation (`@<a>`)
+- [Vim-style](https://github.com/reeflective/readline/wiki/Macros#vim) macro recording (`q<a>`) and invocation (`@<a>`)
 
 ### Interface
-- Support for PS1/PS2/RPROMPT/transient/tooltip prompts (compatible with [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh))
-- Extended completion system, keymap-based and configurable, easy to populate & use
+- Support for PS1/PS2/RPROMPT/transient/tooltip [prompts](https://github.com/reeflective/readline/wiki/Prompts) (compatible with [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh))
+- Extended completion system, [keymap-based and configurable](https://github.com/reeflective/readline/wiki/Keymaps-&-Widgets#completion), easy to populate & use
 - Multiple completion display styles, with color support.
 - Completion & History incremental search system & highlighting (fuzzy-search).
 - Automatic & context-aware suffix removal for efficient flags/path/list completion.
 - Optional asynchronous autocomplete
-- Builtin & programmable syntax highlighting
+- Builtin & programmable [syntax highlighting](https://github.com/reeflective/readline/wiki/Syntax-Highlighting)
 
 
 ## Documentation
@@ -91,12 +91,15 @@ functionality provided by readline and its default configuration, install and st
 * [Introduction](https://github.com/reeflective/readline/wiki/Introduction-&-Features)
 * [Configuration file](https://github.com/reeflective/readline/wiki/Configuration-File)
 * [Keymaps & Widgets](https://github.com/reeflective/readline/wiki/Keymaps-&-Widgets)
+* [Default Binds & Options](https://github.com/reeflective/readline/wiki/Default-Binds-&-Options)
 * [Prompts](https://github.com/reeflective/readline/wiki/Prompts)
 * [History Sources](https://github.com/reeflective/readline/wiki/History-Sources)
 * [Vim mode](https://github.com/reeflective/readline/wiki/Vim-Mode)
 * [Custom callbacks](https://github.com/reeflective/readline/wiki/Custom-Callbacks)
+* [Programmable Commands](https://github.com/reeflective/readline/wiki/Programmable-Commands)
 * [Completions & Hints](https://github.com/reeflective/readline/wiki/Completions-&-Hints)
 * [Other features](https://github.com/reeflective/readline/wiki/Other-Features)
+* [Multiline support](https://github.com/reeflective/readline/wiki/Multiline)
 
 
 ## Showcases
@@ -168,13 +171,15 @@ History movement, completion and some other other widgets
 
 ## Status
 
-This library is in a pre-release status, although pretending to be quite bug-free as compared to its feature set.
-Please open a PR or an issue if you wish to bring enhancements to it. 
-Other contributions, as well as bug fixes and reviews are also welcome.
+This library is now in a release status, as it has underwent several major rewrites and is now considered mostly
+feature-complete, with a solid testing suite to ensure safe and smooth operation to the best extent possible.
+New releases will be regularly pushed when bugs are found and corrected.
+
+- Please open a PR or an issue if you face any bug, and it will be promptly resolved.
+- Don't hesitate proposing a new feature or a PR if you deem it to be useful to most users.
 
 ## Credits
 
-- While most of the code has been rewritten from scratch, the original library used 
-  is [lmorg/readline](https://github.com/lmorg/readline). I would have never ventured myself doing this if he had not 
-  ventured writing a Vim mode core in the first place. 
+- Big thanks to @kenshaw for his `.inputrc` parsing package, which brings much wider compatiblity to this library.
 - Some of the Vim code is inspired or translated from [zsh-vi-mode](https://github.com/jeffreytse/zsh-vi-mode).
+- Thanks to [lmorg/readline](https://github.com/lmorg/readline), for the core idea and the line tokenizers.


### PR DESCRIPTION
- Fixes to completion display & cursor pos queries
- Make log functions have fmt.Print() signature
- Better command comp format + cleanups
- Get rid of testify dependencies
- Fix prompt rendering at bottom of terminal
- Fix accept-line with isearch mode
- Fixes to isearch/completion escape/accept-line
- Fix completion selection alias movements
- Implement magic space
- Fix transient prompt display
- Fixes to display engine
- Remove redundant type declarations
- Fix inputrc parsing logic
- Fix default bind maps
- Fix completion arrow keys selector
- Fix completion and autosuggestion sync
- Fix iterations and their hints
- Last fixes to iterations
- Fix all orders of pending/iterations execs
- Finish macro stuff and fixes in paste commands
- Fix escape logic in key matching code
- Enhance max comp lines
- Finish adding completion commands
- Multiple history commands + related changes/fixes
- Fix accept-and-hold + history entry duplicates
- Add remaining history control commands
- Add non-incremental search modes/commands
- Enhance non-isearch modes switching
- Add doc comments to emacs commands
- Add doc comments to Vim commands
- Add doc comments to history & completion commands
- Finish vi-search/vi-search again commands
- Remove old comments
- Add last completion command
- Fixes to completion insertion reset details
- Fix inputrc tests on Windows
- Try windows newline delimiter
- Try to fix windows test failing on github
- Try using powershell
- Another try
- Fix all incremental search details and commands
- Highlight matching parens
- Configurable comment sign highlight
- Configurable active region colors
- Inputrc config support in history stuff
- Multiple fixes and enhancements to Vim operator commands
- Implement undo/redo for all lines in history
- Implement various completion inputrc settings
- Changes in core code before next commit
- Map some interrupt signals to readline shell
- Changes to core exports before next commit
- Naming changes related to previous commit
- Export shell readline functionality: - Give access to all components of the shell and the functionality they   provide. - Delete old, unused code related to this. - Small refactors, unrelated.
- Fix spacing in prompts + when reloading config
- Add dependency for correct character count
- Fix tabulations insertion/display/movement
- Fix metacharacters lines computations for display
- Multiple big fixes and refactorings: - All meta/escape prefixes work, even better than stock readline   (ability to combine Meta-char movement binds in Emacs, and 8-bit   characters) - Refactor key input reading/management code, fully working. - All related changes/refactors/fixes
- Cleanups
- Fixes to line and selection
- Upgrade go version
- Try something else to fix windows test
- Update go version for CI/CD
- Another try...
- Update labeler
- Add regexp-based keyword matching command (ex. URL parts)
- Fixes to selection with tab characters
- Add hints for active register + fixes in line display
- Fixes to risky indexings
- Better editor support + fixes
- Update inputrc
- Multiple fixes to history-search + 2 new commands
- Add cursor functions for safe access && replacement
- Add library/term/mode defaults to inputrc parsing
- Fix imports
- History/inputrc fixes + add some emacs default binds
- Fix default Vim keybinds
- Add default Vim insert keys
- Rename some keymaps
- Make surround functionality as Vi-opp
- New Vim-style macro commands + fixes
- Fixes to non-incremental-search insert/abort
- Fix isearch enter/exit insert modes
- Fixes to incremental search cancelling
- Finally fix cursor pos queries async
- Fix double recording of macros
- Enhancements to hints
- Fix shell-backward-kill-word
- Fixes to Vim register completion && esc-handling
- Enable completion keys in isearch mode
- Implement optional syntax autopairs completion/removal
- Fixes to line tokenization
- Fix completion cancelling inserted
- Big overhaul of the keys engine & related: - Keys are now more efficiently poped/matched/dispatched. - Keys read as arguments in commands are saved, so that if the macro   engine is recording, those keys will be saved as well. - Smaller public API for the keys type.
- Fix to line state changes saving
- Temporarily pause Windows CI/CD
- Lint color/term/strutil packages
- Lint editor package
- Lint/clean display and move highlighting code.
- Lint UI package and related display code
- Lint macro engine
- Lint keymap package
- Lint history package
- Lint completion package
- Lint cursor code
- Lint iterations
- Lint keys
- Lint line code
- Lint line code
- Unexport hint section display/coordinates methods
- Lint history commands
- Lint emacs/Vim commands code
- Fixes to key dispatch
- Better hint when no completions
- Lint main readline loop
- Fixes
- Fixes and comments
- Fix missing allowed historycommands in isearch mode
- Fix cancelling completion insertion (isearch/menuselect)
- Fixes to suffix-autoremove behavior
- Full line code test coverage
- Full cursor code test coverage
- Update README
- First part of better coverage (selection)
- Add method to insert at cursor position
- Add most of remaining selection test coverage
- Add tests label
- Finish selection code test coverage
- Add tests for iterations
- End iterations tests
- Handle quoted words in completion & fix suffix preservation
- Add option to justify completion descriptions for tags
- Enhance suffix-autoremoval default behavior
- Fix error messages suppression
- Update README
