### PR TITLE
General fixes

### DIFF
--- a/inputrc/config.go
+++ b/inputrc/config.go
@@ -130,7 +130,7 @@ type Bind struct {
 // ConfigOption is a inputrc config handler option.
 type ConfigOption func(*Config)
 
-// WithConfigReadFileReadFileFunc is a inputrc config option to set the func used
+// WithConfigReadFileFunc is a inputrc config option to set the func used
 // for ReadFile operations.
 func WithConfigReadFileFunc(readFileFunc func(string) ([]byte, error)) ConfigOption {
 	return func(cfg *Config) {

--- a/inputrc/parse.go
+++ b/inputrc/parse.go
@@ -548,40 +548,40 @@ func unescapeRunes(r []rune, i, end int) string {
 			switch {
 			case c1 == 'a': // \a alert (bell)
 				s = append(s, Alert)
-				i += 1
+				i++
 			case c1 == 'b': // \b backspace
 				s = append(s, Backspace)
-				i += 1
+				i++
 			case c1 == 'd': // \d delete
 				s = append(s, Delete)
-				i += 1
+				i++
 			case c1 == 'e': // \e escape
 				s = append(s, Esc)
-				i += 1
+				i++
 			case c1 == 'f': // \f form feed
 				s = append(s, Formfeed)
-				i += 1
+				i++
 			case c1 == 'n': // \n new line
 				s = append(s, Newline)
-				i += 1
+				i++
 			case c1 == 'r': // \r carriage return
 				s = append(s, Return)
-				i += 1
+				i++
 			case c1 == 't': // \t tab
 				s = append(s, Tab)
-				i += 1
+				i++
 			case c1 == 'v': // \v vertical
 				s = append(s, Vertical)
-				i += 1
+				i++
 			case c1 == '\\', c1 == '"', c1 == '\'': // \\ \" \' literal
 				s = append(s, c1)
-				i += 1
+				i++
 			case c1 == 'x' && hexDigit(c2) && hexDigit(c3): // \xHH hex
 				s = append(s, hexVal(c2)<<4|hexVal(c3))
 				i += 2
 			case c1 == 'x' && hexDigit(c2): // \xH hex
 				s = append(s, hexVal(c2))
-				i += 1
+				i++
 			case octDigit(c1) && octDigit(c2) && octDigit(c3): // \nnn octal
 				s = append(s, (c1-'0')<<6|(c2-'0')<<3|(c3-'0'))
 				i += 3
@@ -590,7 +590,7 @@ func unescapeRunes(r []rune, i, end int) string {
 				i += 2
 			case octDigit(c1): // \n octal
 				s = append(s, c1-'0')
-				i += 1
+				i++
 			case ((c1 == 'C' && c4 == 'M') || (c1 == 'M' && c4 == 'C')) && c2 == '-' && c3 == '\\' && c5 == '-':
 				// \C-\M- or \M-\C- control meta prefix
 				if c6 := grab(r, i+6, end); c6 != 0 {
@@ -614,7 +614,7 @@ func unescapeRunes(r []rune, i, end int) string {
 				}
 			default:
 				s = append(s, c1)
-				i += 1
+				i++
 			}
 			continue
 		}

--- a/internal/completion/insert.go
+++ b/internal/completion/insert.go
@@ -1,7 +1,6 @@
 package completion
 
 import (
-	"strings"
 	"unicode"
 
 	"github.com/reeflective/readline/inputrc"
@@ -177,31 +176,11 @@ func (e *Engine) prepareSuffix() (comp string) {
 		return
 	}
 
-	suffix := rune(comp[len(comp)-1])
-	keys := e.keys.Caller()
-	key := keys[0]
-
 	// If we are to even consider removing a suffix, we keep the suffix
 	// matcher for later: whatever the decision we take here will be identical
 	// to the one we take while removing suffix in "non-virtual comp" mode.
 	e.sm = cur.noSpace
 	e.sm.pos = e.cursor.Pos() + len(comp) - prefix - 1
-
-	// When the suffix matcher is a wildcard, that just means
-	// it's a noSpace directive: if the currently inserted key
-	// is a space, don't remove anything, but keep it for later.
-	if cur.noSpace.string == "*" && suffix != inputrc.Space && key == inputrc.Space {
-		return
-	}
-
-	// Special case when completing paths: if the comp is ended
-	// by a slash, only remove this slash if the inserted key is
-	// one of the suffix matchers and not a space, otherwise keep it.
-	if strings.HasSuffix(comp, "/") && key != inputrc.Space {
-		if notMatcher(key, cur.noSpace.string) {
-			return
-		}
-	}
 
 	return comp
 }

--- a/internal/completion/insert.go
+++ b/internal/completion/insert.go
@@ -31,7 +31,7 @@ func UpdateInserted(eng *Engine) {
 	// last key typed is an escape, in which case the user wants
 	// to quit incremental search but keeping any selected comp.
 	inserted := eng.mustRemoveInserted()
-	cached := eng.keymap.Local() != keymap.Isearch
+	cached := eng.keymap.Local() != keymap.Isearch && !eng.autoForce
 
 	eng.Cancel(inserted, cached)
 

--- a/internal/completion/isearch.go
+++ b/internal/completion/isearch.go
@@ -192,7 +192,7 @@ func (e *Engine) resetIsearchInsertMode() {
 	}
 
 	if e.keymap.Main() != e.isearchModeExit {
-		e.keymap.SetMain(e.isearchModeExit)
+		e.keymap.SetMain(string(e.isearchModeExit))
 		e.isearchModeExit = ""
 	}
 

--- a/internal/core/iterations.go
+++ b/internal/core/iterations.go
@@ -84,7 +84,7 @@ func (i *Iterations) Reset() {
 	i.pending = false
 }
 
-// Reset resets the iterations if the last command was not one to set them.
+// ResetPostRunIterations resets the iterations if the last command didn't set them.
 // If the reset operated on active iterations, this function returns true.
 func ResetPostRunIterations(iter *Iterations) (hint string) {
 	if iter.pending {

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -30,6 +30,7 @@ type Engine struct {
 	lineRows       int
 	cursorRow      int
 	cursorCol      int
+	hintRows       int
 	compRows       int
 	primaryPrinted bool
 
@@ -278,6 +279,7 @@ func (e *Engine) displayHelpers() {
 
 	// Display hint and completions.
 	ui.DisplayHint(e.hint)
+	e.hintRows = ui.CoordinatesHint(e.hint)
 	completion.Display(e.completer, e.AvailableHelperLines())
 	e.compRows = completion.Coordinates(e.completer)
 
@@ -291,7 +293,7 @@ func (e *Engine) displayHelpers() {
 // It returns half the terminal space if we currently have less than 1/3rd of it below.
 func (e *Engine) AvailableHelperLines() int {
 	_, termHeight, _ := term.GetSize(int(os.Stdin.Fd()))
-	compLines := termHeight - e.startRows - e.lineRows - ui.CoordinatesHint(e.hint) - 1
+	compLines := termHeight - e.startRows - e.lineRows - e.hintRows - 1
 
 	if compLines < (termHeight / oneThirdTerminalHeight) {
 		compLines = (termHeight / halfTerminalHeight) - 1

--- a/internal/keymap/keymap.go
+++ b/internal/keymap/keymap.go
@@ -53,8 +53,11 @@ func (m *Engine) Register(commands map[string]func()) {
 }
 
 // SetMain sets the main keymap of the shell.
-func (m *Engine) SetMain(keymap Mode) {
-	m.main = keymap
+// Valid builtin keymaps are:
+// - emacs, emacs-meta, emacs-ctlx, emacs-standard.
+// - vi, vi-insert, vi-command, vi-move.
+func (m *Engine) SetMain(keymap string) {
+	m.main = Mode(keymap)
 	m.UpdateCursor()
 }
 
@@ -64,8 +67,11 @@ func (m *Engine) Main() Mode {
 }
 
 // SetLocal sets the local keymap of the shell.
-func (m *Engine) SetLocal(keymap Mode) {
-	m.local = keymap
+// Valid builtin keymaps are:
+// - vi-opp, vi-visual. (used in commands like yank, change, delete, etc.)
+// - isearch, menu-select (used in search and completion).
+func (m *Engine) SetLocal(keymap string) {
+	m.local = Mode(keymap)
 	m.UpdateCursor()
 }
 

--- a/internal/keymap/mode.go
+++ b/internal/keymap/mode.go
@@ -8,19 +8,19 @@ type Mode string
 // Their functioning is similar to how ZSH organizes keymaps.
 const (
 	// Editor.
-	Emacs         Mode = "emacs"
-	EmacsMeta     Mode = "emacs-meta"
-	EmacsCtrlX    Mode = "emacs-ctlx"
-	EmacsStandard Mode = "emacs-standard"
+	Emacs         = "emacs"
+	EmacsMeta     = "emacs-meta"
+	EmacsCtrlX    = "emacs-ctlx"
+	EmacsStandard = "emacs-standard"
 
-	ViInsert  Mode = "vi-insert"
-	Vi        Mode = "vi"
-	ViCommand Mode = "vi-command"
-	ViMove    Mode = "vi-move"
-	Visual    Mode = "vi-visual"
-	ViOpp     Mode = "vi-opp"
+	ViInsert  = "vi-insert"
+	Vi        = "vi"
+	ViCommand = "vi-command"
+	ViMove    = "vi-move"
+	Visual    = "vi-visual"
+	ViOpp     = "vi-opp"
 
 	// Completion and search.
-	Isearch    Mode = "isearch"
-	MenuSelect Mode = "menu-select"
+	Isearch    = "isearch"
+	MenuSelect = "menu-select"
 )

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -262,11 +262,6 @@ func (p *Prompt) formatLastPrompt(prompt string) string {
 	status = begin.ReplaceAllString(status, "")
 	status = end.ReplaceAllString(status, "")
 
-	// Remove ClearScreenBelow sequence to avoid flickering
-	prompt = strings.ReplaceAll(prompt, term.ClearScreenBelow, "")
-	prompt = strings.ReplaceAll(prompt, term.ClearLineAfter, "")
-	prompt = strings.ReplaceAll(prompt, term.ClearLine, "")
-
 	return status + prompt
 }
 
@@ -284,7 +279,7 @@ func (p *Prompt) formatRightPrompt(rprompt string, startColumn int) (prompt stri
 	// Check that we have room for a right/tooltip prompt.
 	canPrint = (startColumn+promptLen < termWidth) || startColumn == termWidth
 	if canPrint {
-		prompt = fmt.Sprintf("%s%s", strings.Repeat(" ", padLen), rprompt) // + term.ClearLineAfter
+		prompt = fmt.Sprintf("%s%s", strings.Repeat(" ", padLen), rprompt)
 	}
 
 	return


### PR DESCRIPTION
- Fixes to completion display & cursor pos queries
- Make log functions have fmt.Print() signature
- Better command comp format + cleanups
- Get rid of testify dependencies
- Fix prompt rendering at bottom of terminal
- Fix accept-line with isearch mode
- Fixes to isearch/completion escape/accept-line
- Fix completion selection alias movements
- Implement magic space
- Fix transient prompt display
- Fixes to display engine
- Remove redundant type declarations
- Fix inputrc parsing logic
- Fix default bind maps
- Fix completion arrow keys selector
- Fix completion and autosuggestion sync
- Fix iterations and their hints
- Last fixes to iterations
- Fix all orders of pending/iterations execs
- Finish macro stuff and fixes in paste commands
- Fix escape logic in key matching code
- Enhance max comp lines
- Finish adding completion commands
- Multiple history commands + related changes/fixes
- Fix accept-and-hold + history entry duplicates
- Add remaining history control commands
- Add non-incremental search modes/commands
- Enhance non-isearch modes switching
- Add doc comments to emacs commands
- Add doc comments to Vim commands
- Add doc comments to history & completion commands
- Finish vi-search/vi-search again commands
- Remove old comments
- Add last completion command
- Fixes to completion insertion reset details
- Fix inputrc tests on Windows
- Try windows newline delimiter
- Try to fix windows test failing on github
- Try using powershell
- Another try
- Fix all incremental search details and commands
- Highlight matching parens
- Configurable comment sign highlight
- Configurable active region colors
- Inputrc config support in history stuff
- Multiple fixes and enhancements to Vim operator commands
- Implement undo/redo for all lines in history
- Implement various completion inputrc settings
- Changes in core code before next commit
- Map some interrupt signals to readline shell
- Changes to core exports before next commit
- Naming changes related to previous commit
- Export shell readline functionality: - Give access to all components of the shell and the functionality they   provide. - Delete old, unused code related to this. - Small refactors, unrelated.
- Fix spacing in prompts + when reloading config
- Add dependency for correct character count
- Fix tabulations insertion/display/movement
- Fix metacharacters lines computations for display
- Multiple big fixes and refactorings: - All meta/escape prefixes work, even better than stock readline   (ability to combine Meta-char movement binds in Emacs, and 8-bit   characters) - Refactor key input reading/management code, fully working. - All related changes/refactors/fixes
- Cleanups
- Fixes to line and selection
- Upgrade go version
- Try something else to fix windows test
- Update go version for CI/CD
- Another try...
- Update labeler
- Add regexp-based keyword matching command (ex. URL parts)
- Fixes to selection with tab characters
- Add hints for active register + fixes in line display
- Fixes to risky indexings
- Better editor support + fixes
- Update inputrc
- Multiple fixes to history-search + 2 new commands
- Add cursor functions for safe access && replacement
- Add library/term/mode defaults to inputrc parsing
- Fix imports
- History/inputrc fixes + add some emacs default binds
- Fix default Vim keybinds
- Add default Vim insert keys
- Rename some keymaps
- Make surround functionality as Vi-opp
- New Vim-style macro commands + fixes
- Fixes to non-incremental-search insert/abort
- Fix isearch enter/exit insert modes
- Fixes to incremental search cancelling
- Finally fix cursor pos queries async
- Fix double recording of macros
- Enhancements to hints
- Fix shell-backward-kill-word
- Fixes to Vim register completion && esc-handling
- Enable completion keys in isearch mode
- Implement optional syntax autopairs completion/removal
- Fixes to line tokenization
- Fix completion cancelling inserted
- Big overhaul of the keys engine & related: - Keys are now more efficiently poped/matched/dispatched. - Keys read as arguments in commands are saved, so that if the macro   engine is recording, those keys will be saved as well. - Smaller public API for the keys type.
- Fix to line state changes saving
- Temporarily pause Windows CI/CD
- Lint color/term/strutil packages
- Lint editor package
- Lint/clean display and move highlighting code.
- Lint UI package and related display code
- Lint macro engine
- Lint keymap package
- Lint history package
- Lint completion package
- Lint cursor code
- Lint iterations
- Lint keys
- Lint line code
- Lint line code
- Unexport hint section display/coordinates methods
- Lint history commands
- Lint emacs/Vim commands code
- Fixes to key dispatch
- Better hint when no completions
- Lint main readline loop
- Fixes
- Fixes and comments
- Fix missing allowed historycommands in isearch mode
- Fix cancelling completion insertion (isearch/menuselect)
- Fixes to suffix-autoremove behavior
- Full line code test coverage
- Full cursor code test coverage
- Update README
- First part of better coverage (selection)
- Add method to insert at cursor position
- Add most of remaining selection test coverage
- Add tests label
- Finish selection code test coverage
- Add tests for iterations
- End iterations tests
- Handle quoted words in completion & fix suffix preservation
- Add option to justify completion descriptions for tags
- Enhance suffix-autoremoval default behavior
- Fix error messages suppression
- Update README
- Update README and fixes to digit-argument keys
- Fix lagging history completions
- Fix security checks
- Remove redundant code
- Update dependencies
- Fixes to security checks
- End of previous commit
- Use simple string as keymap modes
- Fix some history autocomplete modes
- Try fixing new flickering
- Remove useless suffix code
