### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,5 +174,6 @@ Additionally:
 ## Credits
 
 - Big thanks to @kenshaw for his `.inputrc` parsing package, which brings much wider compatiblity to this library.
+- The famous `chzyer/readline` for the Windows I/O code and everything related.
 - Some of the Vim code is inspired or translated from [zsh-vi-mode](https://github.com/jeffreytse/zsh-vi-mode).
-- Thanks to [lmorg/readline](https://github.com/lmorg/readline), for the core idea and the line tokenizers.
+- Thanks to [lmorg/readline](https://github.com/lmorg/readline), for the line tokenizers.

--- a/completion.go
+++ b/completion.go
@@ -247,7 +247,6 @@ func (rl *Shell) historyCompletion(forward, filterLine, substring bool) {
 		completer := func() completion.Values {
 			maxLines := rl.Display.AvailableHelperLines()
 			return history.Complete(rl.History, forward, filterLine, maxLines, rl.completer.IsearchRegex)
-			// return rl.History.Complete(forward, filterLine)
 		}
 
 		if substring {

--- a/history.go
+++ b/history.go
@@ -641,7 +641,6 @@ func (rl *Shell) acceptLineWith(infer, hold bool) {
 		defer rl.completer.NonIsearchStop()
 
 		line, cursor, _ := rl.completer.GetBuffer()
-
 		rl.History.InsertMatch(line, cursor, true, forward, substring)
 
 		return

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -71,20 +71,15 @@ var (
 
 // Text effects.
 const (
-	SGRStart     = "\x1b["
-	FgColorStart = "38;05;"
-	BgColorStart = "48;05;"
-	SGREnd       = "m"
+	SGRStart = "\x1b["
+	Fg       = "38;05;"
+	Bg       = "48;05;"
+	SGREnd   = "m"
 )
 
-// SGR formats a color code as an ANSI escaped color sequence.
-func SGR(color string, fg bool) string {
-	if fg {
-		return SGRStart + FgColorStart + color + SGREnd
-		// return SGRStart + color + SGREnd
-	}
-
-	return SGRStart + BgColorStart + color + SGREnd
+// Fmt formats a color code as an ANSI escaped color sequence.
+func Fmt(color string) string {
+	return SGRStart + color + SGREnd
 }
 
 // HasEffects returns true if colors and effects are supported
@@ -164,3 +159,14 @@ var re = regexp.MustCompile(ansi)
 func Strip(str string) string {
 	return re.ReplaceAllString(str, "")
 }
+
+// wrong: reapplies fg/bg escapes regardless of the string passed.
+// Users should be in charge of applying any effect as they wish.
+// func SGR(color string, fg bool) string {
+// 	if fg {
+// 		return SGRStart + FgColorStart + color + SGREnd
+// 		// return SGRStart + color + SGREnd
+// 	}
+//
+// 	return SGRStart + BgColorStart + color + SGREnd
+// }

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -80,7 +80,8 @@ const (
 // SGR formats a color code as an ANSI escaped color sequence.
 func SGR(color string, fg bool) string {
 	if fg {
-		return SGRStart + color + SGREnd
+		return SGRStart + FgColorStart + color + SGREnd
+		// return SGRStart + color + SGREnd
 	}
 
 	return SGRStart + BgColorStart + color + SGREnd

--- a/internal/completion/engine.go
+++ b/internal/completion/engine.go
@@ -259,9 +259,14 @@ func (e *Engine) ClearMenu(completions bool) {
 // IsActive indicates if the engine is currently in possession of a
 // non-empty list of generated completions (following all constraints).
 func (e *Engine) IsActive() bool {
-	return e.keymap.Local() == keymap.MenuSelect ||
-		e.keymap.Local() == keymap.Isearch ||
+	completing := e.keymap.Local() == keymap.MenuSelect
+
+	isearching := e.keymap.Local() == keymap.Isearch ||
 		e.auto || e.autoForce
+
+	nonIsearching, _, _ := e.NonIncrementallySearching()
+
+	return (completing || isearching) && !nonIsearching
 }
 
 // IsInserting returns true if a candidate is currently virtually inserted.

--- a/internal/completion/engine.go
+++ b/internal/completion/engine.go
@@ -83,7 +83,10 @@ func (e *Engine) Generate(completions Values) {
 		e.ClearMenu(true)
 	}
 
-	if e.hasUniqueCandidate() {
+	// Incremental search is a special case, because the user may
+	// want to keep searching for another match, so we don't drop
+	// the completion list and exit the incremental search mode.
+	if e.hasUniqueCandidate() && e.keymap.Local() != keymap.Isearch {
 		e.acceptCandidate()
 		e.ClearMenu(true)
 	}

--- a/internal/completion/group.go
+++ b/internal/completion/group.go
@@ -622,7 +622,7 @@ func (g *group) highlightCandidate(eng *Engine, val Candidate, cell, pad string,
 	switch {
 	// If the comp is currently selected, overwrite any highlighting already applied.
 	case selected:
-		candidate = color.Fmt("255") + color.FgBlackBright + g.displayTrimmed(color.Strip(val.Display))
+		candidate = color.Fmt(color.Bg+"255") + color.FgBlackBright + g.displayTrimmed(color.Strip(val.Display))
 		if g.aliased {
 			candidate += cell + color.Reset
 		}
@@ -656,7 +656,7 @@ func (g *group) highlightDescription(eng *Engine, val Candidate, row, col int) (
 
 	// If the comp is currently selected, overwrite any highlighting already applied.
 	if row == g.posY && col == g.posX && g.isCurrent && !g.aliased {
-		desc = color.Fmt("255") + color.FgBlackBright + g.descriptionTrimmed(val.Description)
+		desc = color.Fmt(color.Bg+"255") + color.FgBlackBright + g.descriptionTrimmed(val.Description)
 	}
 
 	return color.Dim + desc + color.Reset

--- a/internal/completion/group.go
+++ b/internal/completion/group.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -611,19 +610,19 @@ func (g *group) writeRow(eng *Engine, row int) (comp string) {
 }
 
 func (g *group) highlightCandidate(eng *Engine, val Candidate, cell, pad string, selected bool) (candidate string) {
-	reset := color.SGR(val.Style, true)
+	reset := color.Fmt(val.Style)
 	candidate = g.displayTrimmed(val.Display)
 
 	if eng.IsearchRegex != nil && eng.isearchBuf.Len() > 0 {
 		match := eng.IsearchRegex.FindString(candidate)
-		match = color.SGR("244", false) + match + color.Reset + reset
+		match = color.Fmt(color.Bg+"244") + match + color.Reset + reset
 		candidate = eng.IsearchRegex.ReplaceAllLiteralString(candidate, match)
 	}
 
 	switch {
 	// If the comp is currently selected, overwrite any highlighting already applied.
 	case selected:
-		candidate = color.SGR(strconv.Itoa(255), false) + color.FgBlackBright + g.displayTrimmed(color.Strip(val.Display))
+		candidate = color.Fmt("255") + color.FgBlackBright + g.displayTrimmed(color.Strip(val.Display))
 		if g.aliased {
 			candidate += cell + color.Reset
 		}
@@ -651,13 +650,13 @@ func (g *group) highlightDescription(eng *Engine, val Candidate, row, col int) (
 
 	if eng.IsearchRegex != nil && eng.isearchBuf.Len() > 0 {
 		match := eng.IsearchRegex.FindString(desc)
-		match = color.SGR("244", false) + match + color.Reset + color.Dim
+		match = color.Fmt("244") + match + color.Reset + color.Dim
 		desc = eng.IsearchRegex.ReplaceAllLiteralString(desc, match)
 	}
 
 	// If the comp is currently selected, overwrite any highlighting already applied.
 	if row == g.posY && col == g.posX && g.isCurrent && !g.aliased {
-		desc = color.SGR(strconv.Itoa(255), false) + color.FgBlackBright + g.descriptionTrimmed(val.Description)
+		desc = color.Fmt("255") + color.FgBlackBright + g.descriptionTrimmed(val.Description)
 	}
 
 	return color.Dim + desc + color.Reset

--- a/internal/completion/group.go
+++ b/internal/completion/group.go
@@ -616,7 +616,7 @@ func (g *group) highlightCandidate(eng *Engine, val Candidate, cell, pad string,
 
 	if eng.IsearchRegex != nil && eng.isearchBuf.Len() > 0 {
 		match := eng.IsearchRegex.FindString(candidate)
-		match = color.BgBlackBright + match + color.Reset + reset
+		match = color.SGR("244", false) + match + color.Reset + reset
 		candidate = eng.IsearchRegex.ReplaceAllLiteralString(candidate, match)
 	}
 
@@ -651,7 +651,7 @@ func (g *group) highlightDescription(eng *Engine, val Candidate, row, col int) (
 
 	if eng.IsearchRegex != nil && eng.isearchBuf.Len() > 0 {
 		match := eng.IsearchRegex.FindString(desc)
-		match = color.BgBlackBright + match + color.Reset + color.Dim
+		match = color.SGR("244", false) + match + color.Reset + color.Dim
 		desc = eng.IsearchRegex.ReplaceAllLiteralString(desc, match)
 	}
 

--- a/internal/completion/insert.go
+++ b/internal/completion/insert.go
@@ -90,9 +90,11 @@ func (e *Engine) refreshLine() {
 		return
 	}
 
-	if e.hasUniqueCandidate() {
+	// Incremental search is a special case, because the user may
+	// want to keep searching for another match, so we don't drop
+	// the completion list and exit the incremental search mode.
+	if e.hasUniqueCandidate() && e.keymap.Local() != keymap.Isearch {
 		e.acceptCandidate()
-		e.ClearMenu(true)
 		e.ResetForce()
 	} else {
 		e.insertCandidate()

--- a/internal/core/api_windows.go
+++ b/internal/core/api_windows.go
@@ -156,3 +156,17 @@ func GetConsoleCursorInfo() (*_CONSOLE_CURSOR_INFO, error) {
 func SetConsoleCursorPosition(c *_COORD) error {
 	return kernel.SetConsoleCursorPosition(stdout, c.ptr())
 }
+
+// GetCursorPos returns the current cursor position on Windows.
+func (k *Keys) GetCursorPos() (x, y int) {
+	t := new(_CONSOLE_SCREEN_BUFFER_INFO)
+	kernel.GetConsoleScreenBufferInfo(
+		stdout,
+		uintptr(unsafe.Pointer(t)),
+	)
+
+	x = int(t.dwCursorPosition.x) + 1
+	y = int(t.dwCursorPosition.y)
+
+	return
+}

--- a/internal/core/keys.go
+++ b/internal/core/keys.go
@@ -2,11 +2,9 @@ package core
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"regexp"
-	"strconv"
 	"sync"
 
 	"github.com/reeflective/readline/inputrc"
@@ -267,81 +265,6 @@ func (k *Keys) Feed(begin bool, keys ...rune) {
 	} else {
 		k.macroKeys = append(k.macroKeys, keyBuf...)
 	}
-}
-
-// GetCursorPos returns the current cursor position in the terminal.
-// It is safe to call this function even if the shell is reading input.
-func (k *Keys) GetCursorPos() (x, y int) {
-	k.cursor = make(chan []byte)
-
-	disable := func() (int, int) {
-		os.Stderr.WriteString("\r\ngetCursorPos() not supported by terminal emulator, disabling....\r\n")
-		return -1, -1
-	}
-
-	var cursor []byte
-	var match [][]string
-
-	// Echo the query and wait for the main key
-	// reading routine to send us the response back.
-	fmt.Print("\x1b[6n")
-
-	// In order not to get stuck with an input that might be user-one
-	// (like when the user typed before the shell is fully started, and yet not having
-	// queried cursor yet), we keep reading from stdin until we find the cursor response.
-	// Everything else is passed back as user input.
-	for {
-		switch {
-		case k.waiting, k.reading:
-			cursor = <-k.cursor
-		default:
-			buf := make([]byte, keyScanBufSize)
-
-			read, err := os.Stdin.Read(buf)
-			if err != nil {
-				return disable()
-			}
-
-			cursor = buf[:read]
-		}
-
-		// We have read (or have been passed) something.
-		if len(cursor) == 0 {
-			return disable()
-		}
-
-		// Attempt to locate cursor response in it.
-		match = rxRcvCursorPos.FindAllStringSubmatch(string(cursor), 1)
-
-		// If there is something but not cursor answer, its user input.
-		if len(match) == 0 && len(cursor) > 0 {
-			k.mutex.RLock()
-			k.buf = append(k.buf, cursor...)
-			k.mutex.RUnlock()
-
-			continue
-		}
-
-		// And if empty, then we should abort.
-		if len(match) == 0 {
-			return disable()
-		}
-
-		break
-	}
-
-	// We know that we have a cursor answer, process it.
-	y, err := strconv.Atoi(match[0][1])
-	if err != nil {
-		return disable()
-	}
-
-	x, err = strconv.Atoi(match[0][2])
-	if err != nil {
-		return disable()
-	}
-
-	return x, y
 }
 
 func (k *Keys) extractCursorPos(keys []byte) (cursor, remain []byte) {

--- a/internal/core/keys_unix.go
+++ b/internal/core/keys_unix.go
@@ -1,0 +1,84 @@
+//go:build unix
+
+package core
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// GetCursorPos returns the current cursor position in the terminal.
+// It is safe to call this function even if the shell is reading input.
+func (k *Keys) GetCursorPos() (x, y int) {
+	k.cursor = make(chan []byte)
+
+	disable := func() (int, int) {
+		os.Stderr.WriteString("\r\ngetCursorPos() not supported by terminal emulator, disabling....\r\n")
+		return -1, -1
+	}
+
+	var cursor []byte
+	var match [][]string
+
+	// Echo the query and wait for the main key
+	// reading routine to send us the response back.
+	fmt.Print("\x1b[6n")
+
+	// In order not to get stuck with an input that might be user-one
+	// (like when the user typed before the shell is fully started, and yet not having
+	// queried cursor yet), we keep reading from stdin until we find the cursor response.
+	// Everything else is passed back as user input.
+	for {
+		switch {
+		case k.waiting, k.reading:
+			cursor = <-k.cursor
+		default:
+			buf := make([]byte, keyScanBufSize)
+
+			read, err := os.Stdin.Read(buf)
+			if err != nil {
+				return disable()
+			}
+
+			cursor = buf[:read]
+		}
+
+		// We have read (or have been passed) something.
+		if len(cursor) == 0 {
+			return disable()
+		}
+
+		// Attempt to locate cursor response in it.
+		match = rxRcvCursorPos.FindAllStringSubmatch(string(cursor), 1)
+
+		// If there is something but not cursor answer, its user input.
+		if len(match) == 0 && len(cursor) > 0 {
+			k.mutex.RLock()
+			k.buf = append(k.buf, cursor...)
+			k.mutex.RUnlock()
+
+			continue
+		}
+
+		// And if empty, then we should abort.
+		if len(match) == 0 {
+			return disable()
+		}
+
+		break
+	}
+
+	// We know that we have a cursor answer, process it.
+	y, err := strconv.Atoi(match[0][1])
+	if err != nil {
+		return disable()
+	}
+
+	x, err = strconv.Atoi(match[0][2])
+	if err != nil {
+		return disable()
+	}
+
+	return x, y
+}

--- a/internal/core/selection.go
+++ b/internal/core/selection.go
@@ -578,7 +578,7 @@ func HighlightMatchers(sel *Selection) {
 			visual: true,
 			bpos:   ppos,
 			epos:   ppos,
-			bg:     color.SGR("240", false),
+			bg:     color.Fmt("240"),
 			line:   sel.line,
 			cursor: sel.cursor,
 		})

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -293,10 +293,10 @@ func (e *Engine) displayHelpers() {
 // It returns half the terminal space if we currently have less than 1/3rd of it below.
 func (e *Engine) AvailableHelperLines() int {
 	_, termHeight, _ := term.GetSize(int(os.Stdout.Fd()))
-	compLines := termHeight - e.startRows - e.lineRows - e.hintRows - 1
+	compLines := termHeight - e.startRows - e.lineRows - e.hintRows
 
 	if compLines < (termHeight / oneThirdTerminalHeight) {
-		compLines = (termHeight / halfTerminalHeight) - 1
+		compLines = (termHeight / halfTerminalHeight)
 	}
 
 	return compLines

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -252,7 +252,7 @@ func (e *Engine) displayLine() {
 
 	// Get the subset of the suggested line to print.
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
-		line += color.Dim + color.FgWhite + string(e.suggested[e.line.Len():]) + color.Reset
+		line += color.Dim + color.SGR("243", true) + string(e.suggested[e.line.Len():]) + color.Reset
 	}
 
 	// Format tabs as spaces, for consistent display
@@ -263,7 +263,7 @@ func (e *Engine) displayLine() {
 	core.DisplayLine(&e.suggested, e.startCols)
 
 	// Adjust the cursor if the line fits exactly in the terminal width.
-	if e.lineCol == 0 && e.cursorCol == 0 && e.cursorRow > 1 {
+	if e.lineCol == 0 && e.cursorCol == 0 {
 		fmt.Println()
 	}
 }

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -252,7 +252,7 @@ func (e *Engine) displayLine() {
 
 	// Get the subset of the suggested line to print.
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
-		line += color.Dim + color.SGR("243", true) + string(e.suggested[e.line.Len():]) + color.Reset
+		line += color.Dim + color.Fmt("243") + string(e.suggested[e.line.Len():]) + color.Reset
 	}
 
 	// Format tabs as spaces, for consistent display

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -252,7 +252,7 @@ func (e *Engine) displayLine() {
 
 	// Get the subset of the suggested line to print.
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
-		line += color.Dim + color.Fmt("243") + string(e.suggested[e.line.Len():]) + color.Reset
+		line += color.Dim + color.Fmt(color.Fg+"242") + string(e.suggested[e.line.Len():]) + color.Reset
 	}
 
 	// Format tabs as spaces, for consistent display

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -252,7 +252,7 @@ func (e *Engine) displayLine() {
 
 	// Get the subset of the suggested line to print.
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
-		line += color.FgBlackBright + string(e.suggested[e.line.Len():]) + color.Reset
+		line += color.Dim + color.FgWhite + string(e.suggested[e.line.Len():]) + color.Reset
 	}
 
 	// Format tabs as spaces, for consistent display

--- a/internal/display/highlight.go
+++ b/internal/display/highlight.go
@@ -35,7 +35,7 @@ func (e *Engine) highlightLine(line []rune, selection core.Selection) string {
 	commentPattern := fmt.Sprintf(`(^|\s)%s.*`, comment)
 
 	if commentsMatch, err := regexp.Compile(commentPattern); err == nil {
-		commentColor := color.SGRStart + color.Fg + "248" + color.SGREnd
+		commentColor := color.SGRStart + color.Fg + "244" + color.SGREnd
 		highlighted = commentsMatch.ReplaceAllString(highlighted, fmt.Sprintf("%s${0}%s", commentColor, color.Reset))
 	}
 

--- a/internal/display/highlight.go
+++ b/internal/display/highlight.go
@@ -35,7 +35,7 @@ func (e *Engine) highlightLine(line []rune, selection core.Selection) string {
 	commentPattern := fmt.Sprintf(`(^|\s)%s.*`, comment)
 
 	if commentsMatch, err := regexp.Compile(commentPattern); err == nil {
-		commentColor := color.SGRStart + color.FgColorStart + "248" + color.SGREnd
+		commentColor := color.SGRStart + color.Fg + "248" + color.SGREnd
 		highlighted = commentsMatch.ReplaceAllString(highlighted, fmt.Sprintf("%s${0}%s", commentColor, color.Reset))
 	}
 

--- a/internal/history/sources.go
+++ b/internal/history/sources.go
@@ -177,6 +177,7 @@ func (h *Sources) Walk(pos int) {
 		h.skip = false
 		h.Save()
 		h.cpos = -1
+		h.hpos = 0
 	}
 
 	h.hpos += pos
@@ -185,11 +186,11 @@ func (h *Sources) Walk(pos int) {
 	case h.hpos < -1:
 		h.hpos = -1
 		return
-	case h.hpos == -1:
+	case h.hpos == 0:
 		h.restoreLineBuffer()
 		return
-	case h.hpos >= history.Len():
-		h.hpos = history.Len() - 1
+	case h.hpos > history.Len():
+		h.hpos = history.Len()
 		return
 	}
 
@@ -200,7 +201,7 @@ func (h *Sources) Walk(pos int) {
 	// this line, use it instead of the fetched line.
 	if hist := h.getLineHistory(); hist != nil && len(hist.items) > 0 {
 		line = hist.items[len(hist.items)-1].line
-	} else if line, err = history.GetLine(history.Len() - h.hpos - 1); err != nil {
+	} else if line, err = history.GetLine(history.Len() - h.hpos); err != nil {
 		h.hint.Set(color.FgRed + "history error: " + err.Error())
 		return
 	}

--- a/internal/history/sources.go
+++ b/internal/history/sources.go
@@ -172,6 +172,10 @@ func (h *Sources) Walk(pos int) {
 		return
 	}
 
+	if h.hpos == history.Len() && pos == 1 {
+		return
+	}
+
 	// Save the current line buffer if we are leaving it.
 	if h.hpos == -1 && pos > 0 {
 		h.skip = false
@@ -191,7 +195,6 @@ func (h *Sources) Walk(pos int) {
 		return
 	case h.hpos > history.Len():
 		h.hpos = history.Len()
-		return
 	}
 
 	var line string

--- a/internal/history/undo.go
+++ b/internal/history/undo.go
@@ -232,6 +232,8 @@ func (h *Sources) getLineHistory() *lineHistory {
 }
 
 func (h *Sources) restoreLineBuffer() {
+	h.hpos = -1
+
 	hist := h.getHistoryLineChanges()
 	if hist == nil {
 		return
@@ -239,7 +241,7 @@ func (h *Sources) restoreLineBuffer() {
 
 	// Get the undo states for the line buffer
 	// (the last one, not any of the history ones)
-	lh := hist[-1]
+	lh := hist[h.hpos]
 	if lh == nil || len(lh.items) == 0 {
 		return
 	}

--- a/internal/history/undo.go
+++ b/internal/history/undo.go
@@ -216,10 +216,10 @@ func (h *Sources) getLineHistory() *lineHistory {
 	}
 
 	// Compute the position of the current line in the history.
-	linePos := 0
+	linePos := -1
 
 	history := h.Current()
-	if h.hpos > 0 && history != nil {
+	if h.hpos > -1 && history != nil {
 		linePos = history.Len() - h.hpos
 	}
 
@@ -239,7 +239,7 @@ func (h *Sources) restoreLineBuffer() {
 
 	// Get the undo states for the line buffer
 	// (the last one, not any of the history ones)
-	lh := hist[0]
+	lh := hist[-1]
 	if lh == nil || len(lh.items) == 0 {
 		return
 	}

--- a/internal/term/raw_windows.go
+++ b/internal/term/raw_windows.go
@@ -70,5 +70,9 @@ func GetSize(fd int) (width, height int, err error) {
 	if err := windows.GetConsoleScreenBufferInfo(windows.Handle(fd), &info); err != nil {
 		return 0, 0, err
 	}
-	return int(info.Size.X), int(info.Size.Y), nil
+
+	width = int(info.Size.X)
+	height = int(info.Size.Y) - 1 // Needs an adjustment
+
+	return width, height, nil
 }

--- a/internal/ui/hint.go
+++ b/internal/ui/hint.go
@@ -136,9 +136,10 @@ func CoordinatesHint(hint *Hint) int {
 
 	for i, line := range lines {
 		x, y := strutil.LineSpan([]rune(line), i, 0)
-		if x != 0 && y == 0 {
+		if x != 0 {
 			y++
 		}
+
 		usedY += y
 	}
 


### PR DESCRIPTION
- Remove documentation toc from README
- Tidy the API
- Multiple fixes and new save-line command
- History fixes
- Fix hint errors display
- Fix autosuggest forward-char
- Fix cursor to beginning of line
- Fixes to autosuggest and reset default cursor on exit
- Fix some line updates in isearch mode
- Fix color && padding in comp isearch mode
- Add extended support for Windows
- Little Windows code refactor
- Save various key read/matching bugs/inconsistencies
- Fixes to cursor line move and isearch stuff
- Fix isearch soft-escape in emacs mode
- Fix little prefix bug in isearch history
- Fix Vim escape
- Replace some special metas in default binds
- Multiple major fixes to key dispatch
- Fix Windows cursor position query code
- Fixes to display and better autosuggest color
- Fixes to maximum completions display
- Color fixes to completions
- Fix incremental-search one match
- Fix history line position logic
- More fixes for last commit
- Color fixes
- Fixes to Vim non-incremental search
