### PR TITLE
Fixes and updates to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 
 <div align="center">
   <br> <h1> Readline </h1>
-  <p>  Shell library with modern and simple UI features </p>
 </div>
 
 
@@ -48,25 +47,26 @@ It is used, between others, to power the [console](https://github.com/reeflectiv
 
 ### Core 
 - Pure Go, almost-only standard library
+- Cross-platform (Linux / MacOS / Windows)
 - Full `.inputrc` support (all commands/options)
 - Extensive test suite and full coverage of core code
 - [Extended list](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands) of additional commands/options (edition/completion/history)
 - Complete [multiline edition/movement support](https://github.com/reeflective/readline/wiki/Multiline)
 - Command-line edition in `$EDITOR`/`$VISUAL` support
-- Programmable API, with failure-safe access to core components
+- [Programmable API](https://github.com/reeflective/readline/wiki/Programmable-Commands), with failure-safe access to core components
 - Support for an [arbitrary number of history sources](https://github.com/reeflective/readline/wiki/History-Sources)
 
 ### Emacs / Standard
 - Native Emacs commands
 - Emacs-style [macro engine](https://github.com/reeflective/readline/wiki/Macros#emacs) (not working accross multiple calls)
-- Keywords switching (operators, booleans, hex/binary/digit) with iterations
+- Keywords [switching](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands#modifying-text) (operators, booleans, hex/binary/digit) with iterations
 - Command/mode cursor status indicator
 - Complete undo/redo history
 - Command status/arg/iterations hint display
 
 ### Vim
 - Near-native Vim mode
-- Vim text objects (code blocks/words/blank/shellwords)
+- Vim [text objects](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands#text-objects) (code blocks, words/blank/shellwords)
 - Extended surround select/change/add fonctionality, with highlighting
 - Vim Visual/Operator pending mode & cursor styles indications
 - Vim Insert and Replace (once/many)
@@ -173,7 +173,7 @@ Additionally:
 
 ## Credits
 
-- Big thanks to @kenshaw for his `.inputrc` parsing package, which brings much wider compatiblity to this library.
-- The famous `chzyer/readline` for the Windows I/O code and everything related.
+- @kenshaw for his `.inputrc` parsing package, which brings much wider compatibility to this library.
+- `chzyer/readline` for the Windows I/O code and everything related.
 - Some of the Vim code is inspired or translated from [zsh-vi-mode](https://github.com/jeffreytse/zsh-vi-mode).
-- Thanks to [lmorg/readline](https://github.com/lmorg/readline), for the line tokenizers.
+- [lmorg/readline](https://github.com/lmorg/readline), for the line tokenizers.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,11 @@ The documentation is available on the [repository wiki](https://github.com/reefl
 <img src="https://github.com/reeflective/readline/blob/assets/undo.gif"/>
 </details>
 <details>
-  <summary>- Keyword switching </summary>
+  <summary>- Keyword switching & selection </summary>
+ <dd><em>Switching various keywords</em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/switch-keywords.gif"/>
+ <dd><em>Using regexp-based selection to grab parts of words (here, URL components)</em></dd>
+<img src="https://github.com/reeflective/readline/blob/assets/select-keywords.gif"/>
 </details>
 <details>
   <summary>- Vim selection & movements (basic) </summary>
@@ -116,32 +119,25 @@ The documentation is available on the [repository wiki](https://github.com/reefl
 </details>
 <details>
   <summary>- Vim surround (selection and change) </summary>
- <dd><em>Basic surround selection changes/adds</em></dd>
+ <dd><em>Selecting/adding/changing surround regions</em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/vim-surround.gif"/>
  <dd><em>Surround and change in shellwords, matching brackets, etc.</em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/vim-surround-2.gif"/>
 </details>
 <details>
   <summary>- Vim registers (with completion) </summary>
-<img src="https://github.com/reeflective/readline/blob/assets/vim-registers.gif"/>
+<img src="https://github.com/reeflective/readline/blob/assets/registers.gif"/>
 </details>
 <details>
   <summary>- History movements/completion/use/search </summary>
- <dd><em></em></dd>
-History movement, completion and some other other widgets
+ <dd>History movement, completion and some other other widgets<em></em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/history.gif"/>
- <dd><em>History cycling and search</em></dd>
-<img src="https://github.com/reeflective/readline/blob/assets/history-search.gif"/>
 </details>
 <details>
   <summary>- Completion </summary>
  <dd><em>Classic mode & incremental search mode</em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/completion.gif"/>
- <dd><em>Smart terminal estate management</em></dd>
-<img src="https://github.com/reeflective/readline/blob/assets/completion-size.gif"/>
-</details>
-<details>
-  <summary>- Suffix autoremoval </summary>
+ <dd><em>Suffix-autoremoval </em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/suffix-autoremoval.gif"/>
 </details>
 <details>
@@ -153,8 +149,12 @@ History movement, completion and some other other widgets
 <img src="https://github.com/reeflective/readline/blob/assets/logging.gif"/>
 </details>
 <details>
-  <summary>- Configuration hot-reload </summary>
-<img src="https://github.com/reeflective/readline/blob/assets/configuration-reload.gif"/>
+  <summary>- Inputrc init file reload </summary>
+<img src="https://github.com/reeflective/readline/blob/assets/config-reload.gif"/>
+</details>
+<details>
+  <summary>- Multiline edition </summary>
+<img src="https://github.com/reeflective/readline/blob/assets/multiline.gif"/>
 </details>
 
 

--- a/internal/completion/group.go
+++ b/internal/completion/group.go
@@ -732,7 +732,7 @@ func (g *group) descriptionTrimmed(desc string) string {
 
 	g.maxDescWidth = termWidth - g.tcMaxLength - len(g.listSeparator) - 1
 
-	if len(desc) > g.maxDescWidth {
+	if len(desc) >= g.maxDescWidth {
 		offset := 4
 		if !g.aliased {
 			offset++

--- a/internal/core/api_windows.go
+++ b/internal/core/api_windows.go
@@ -46,11 +46,11 @@ func (c *_COORD) ptr() uintptr {
 }
 
 const (
-	EVENT_KEY                = 0x0001
-	EVENT_MOUSE              = 0x0002
-	EVENT_WINDOW_BUFFER_SIZE = 0x0004
-	EVENT_MENU               = 0x0008
-	EVENT_FOCUS              = 0x0010
+	EVENT_KEY                = 0x0001 // Event for key press/release
+	EVENT_MOUSE              = 0x0002 // Event for mouse action
+	EVENT_WINDOW_BUFFER_SIZE = 0x0004 // Event for window resize
+	EVENT_MENU               = 0x0008 // Event for the menu keys
+	EVENT_FOCUS              = 0x0010 // Event for focus change
 )
 
 type _KEY_EVENT_RECORD struct {
@@ -96,6 +96,7 @@ type _CONSOLE_CURSOR_INFO struct {
 // CallFunc is a function that calls a Windows API function.
 type CallFunc func(u ...uintptr) error
 
+// NewKernel returns a new Kernel with all the required Windows API functions.
 func NewKernel() *Kernel {
 	k := &Kernel{}
 	kernel32 := syscall.NewLazyDLL("kernel32.dll")
@@ -109,6 +110,7 @@ func NewKernel() *Kernel {
 	return k
 }
 
+// Wrap wraps a Windows API function into a callback function.
 func (k *Kernel) Wrap(p *syscall.LazyProc) CallFunc {
 	return func(args ...uintptr) error {
 		var r0 uintptr
@@ -130,15 +132,15 @@ func (k *Kernel) Wrap(p *syscall.LazyProc) CallFunc {
 		if int(r0) == 0 {
 			if e1 != 0 {
 				return error(e1)
-			} else {
-				return syscall.EINVAL
 			}
+			return syscall.EINVAL
 		}
 		return nil
 	}
 }
 
-func GetConsoleScreenBufferInfo() (*_CONSOLE_SCREEN_BUFFER_INFO, error) {
+// getConsoleScreenBufferInfo returns the current screen buffer information on Windows.
+func getConsoleScreenBufferInfo() (*_CONSOLE_SCREEN_BUFFER_INFO, error) {
 	t := new(_CONSOLE_SCREEN_BUFFER_INFO)
 	err := kernel.GetConsoleScreenBufferInfo(
 		stdout,
@@ -147,13 +149,15 @@ func GetConsoleScreenBufferInfo() (*_CONSOLE_SCREEN_BUFFER_INFO, error) {
 	return t, err
 }
 
-func GetConsoleCursorInfo() (*_CONSOLE_CURSOR_INFO, error) {
+// getConsoleCursorInfo returns the current cursor information on Windows.
+func getConsoleCursorInfo() (*_CONSOLE_CURSOR_INFO, error) {
 	t := new(_CONSOLE_CURSOR_INFO)
 	err := kernel.GetConsoleCursorInfo(stdout, uintptr(unsafe.Pointer(t)))
 	return t, err
 }
 
-func SetConsoleCursorPosition(c *_COORD) error {
+// setConsoleCursorInfo sets the cursor position on Windows.
+func setConsoleCursorPosition(c *_COORD) error {
 	return kernel.SetConsoleCursorPosition(stdout, c.ptr())
 }
 

--- a/internal/core/keys_windows.go
+++ b/internal/core/keys_windows.go
@@ -43,7 +43,7 @@ const (
 )
 
 func init() {
-	Stdin = NewRawReader()
+	Stdin = newRawReader()
 }
 
 // rawReader translates Windows input to ANSI sequences,
@@ -54,8 +54,8 @@ type rawReader struct {
 	shiftKey bool
 }
 
-// NewRawReader returns a new rawReader for Windows.
-func NewRawReader() *rawReader {
+// newRawReader returns a new rawReader for Windows.
+func newRawReader() *rawReader {
 	r := new(rawReader)
 	return r
 }

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -142,6 +142,7 @@ func (e *Engine) AcceptLine() {
 	e.prompt.RightPrint(e.lineCol, false)
 
 	// Go below this non-suggested line and clear everything.
+	term.MoveCursorBackwards(term.GetWidth())
 	fmt.Println()
 }
 

--- a/internal/history/sources.go
+++ b/internal/history/sources.go
@@ -80,7 +80,6 @@ func NewSources(line *core.Line, cur *core.Cursor, hint *ui.Hint, opts *inputrc.
 // to infer a command line from the history, it is performed now.
 func Init(hist *Sources) {
 	defer func() {
-		hist.sourcePos = 0
 		hist.accepted = false
 		hist.acceptLine = nil
 		hist.acceptErr = nil
@@ -97,12 +96,14 @@ func Init(hist *Sources) {
 
 	if !hist.infer {
 		hist.hpos = -1
+		undoHist := hist.getHistoryLineChanges()
+		undoHist[hist.hpos] = &lineHistory{}
+
 		return
 	}
 
 	switch hist.hpos {
 	case -1:
-		// hist.hpos = 0
 	case 0:
 		hist.InferNext()
 	default:
@@ -172,6 +173,7 @@ func (h *Sources) Walk(pos int) {
 		return
 	}
 
+	// Can't go back further than the first line.
 	if h.hpos == history.Len() && pos == 1 {
 		return
 	}

--- a/internal/keymap/dispatch.go
+++ b/internal/keymap/dispatch.go
@@ -169,13 +169,13 @@ func (m *Engine) matchBind(keys []byte, binds map[string]inputrc.Bind) (inputrc.
 	// Iterate over the sorted list of sequences and find all binds
 	// that match the sequence either by prefix or exactly.
 	for _, sequence := range sequences {
-		sequence = strutil.ConvertMeta([]rune(sequence))
+		seq := strutil.ConvertMeta([]rune(sequence))
 
-		if len(string(keys)) < len(sequence) && strings.HasPrefix(sequence, string(keys)) {
+		if len(string(keys)) < len(seq) && strings.HasPrefix(seq, string(keys)) {
 			prefixed = append(prefixed, binds[sequence])
 		}
 
-		if string(keys) == sequence {
+		if string(keys) == seq {
 			match = binds[sequence]
 		}
 	}

--- a/internal/ui/hint.go
+++ b/internal/ui/hint.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/reeflective/readline/inputrc"
 	"github.com/reeflective/readline/internal/color"
 	"github.com/reeflective/readline/internal/strutil"
 	"github.com/reeflective/readline/internal/term"
@@ -95,16 +94,16 @@ func DisplayHint(hint *Hint) {
 	}
 
 	if len(hint.text) > 0 {
-		text += string(hint.text)
+		text += string(hint.text) + "\n"
 	}
 
 	if strutil.RealLength(text) == 0 {
 		return
 	}
 
-	text = strings.Join(strings.Split(text, "\n"), "\n"+term.ClearLineAfter)
+	text = strings.Join(strings.Split(text, "\n"), term.ClearLineAfter+"\n")
 
-	text = "\r" + strings.TrimSuffix(text, "\n") + term.ClearLineAfter + string(inputrc.Newline) + color.Reset
+	text = "\r" + text + term.ClearLineAfter + color.Reset
 
 	if len(text) > 0 {
 		fmt.Print(text)

--- a/readline.go
+++ b/readline.go
@@ -57,7 +57,7 @@ func (rl *Shell) Readline() (string, error) {
 	}
 	defer term.Restore(descriptor, state)
 
-	rl.Prompt.PrimaryPrint()
+	rl.Display.PrintPrimaryPrompt()
 	defer rl.Display.RefreshTransient()
 	defer fmt.Print(keymap.CursorStyle("default"))
 

--- a/shell.go
+++ b/shell.go
@@ -15,9 +15,14 @@ import (
 	"github.com/reeflective/readline/internal/ui"
 )
 
-// Shell is used to encapsulate the parameter group and run time of any given
-// readline instance so that you can reuse the readline API for multiple entry
-// captures without having to repeatedly unload configuration.
+// Shell is the main readline shell instance. It contains all the readline state
+// and methods to run the line editor, manage the inputrc configuration, keymaps
+// and commands.
+// Although each instance contains everything needed to run a line editor, it is
+// recommended to use a single instance per application, and to share it between
+// all the goroutines that need to read user input.
+// Please refer to the README and documentation for more details about the shell
+// and its components, and how to use them.
 type Shell struct {
 	// Core editor
 	line       *core.Line       // The input line buffer and its management methods.
@@ -116,12 +121,14 @@ func NewShell(opts ...inputrc.Option) *Shell {
 // split itself with tokenizers, and displaying itself.
 //
 // When the shell is in incremental-search mode, this line is the minibuffer.
+// The line returned here is thus the input buffer of interest at call time.
 func (rl *Shell) Line() *core.Line { return rl.line }
 
 // Cursor is the cursor position in the current line buffer.
 // Contains methods to set, move, describe and check itself.
 //
 // When the shell is in incremental-search mode, this cursor is the minibuffer's one.
+// The cursor returned here is thus the input buffer cursor of interest at call time.
 func (rl *Shell) Cursor() *core.Cursor { return rl.cursor }
 
 // Selection contains all regions of an input line that are currently selected/marked


### PR DESCRIPTION
- Typos in README
- Fixes to display, line words, cursor position and refresh
- Fixes to completion filtering and display
- Adapt completion insert logic with ignore-case
- Fix update cursor on init file reload
- Fixes to fixes
- Updates to README and unexport some Windows code
- Small fix to comp trimming
- Fix to dispatch
- Fixes to hint
- Fixes to history and display accept-line
- Update README demos
