### PR TITLE
Updates to docs and macro engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is used, between others, to power the [console](https://github.com/reeflectiv
 - Pure Go, almost-only standard library
 - Cross-platform (Linux / MacOS / Windows)
 - Full `.inputrc` support (all commands/options)
-- Extensive test suite and full coverage of core code
+- Extensive test suite and almost full coverage of core code
 - [Extended list](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands) of additional commands/options (edition/completion/history)
 - Complete [multiline edition/movement support](https://github.com/reeflective/readline/wiki/Multiline)
 - Command-line edition in `$EDITOR`/`$VISUAL` support
@@ -130,7 +130,7 @@ The documentation is available on the [repository wiki](https://github.com/reefl
 </details>
 <details>
   <summary>- History movements/completion/use/search </summary>
- <dd>History movement, completion and some other other widgets<em></em></dd>
+ <dd><em>History movement, completion and some other other widgets</em></dd>
 <img src="https://github.com/reeflective/readline/blob/assets/history.gif"/>
 </details>
 <details>
@@ -155,6 +155,13 @@ The documentation is available on the [repository wiki](https://github.com/reefl
 <details>
   <summary>- Multiline edition </summary>
 <img src="https://github.com/reeflective/readline/blob/assets/multiline.gif"/>
+</details>
+<details>
+  <summary>- Macros </summary>
+ <dd><em>Emacs</em></dd>
+<img src="https://github.com/reeflective/readline/blob/assets/emacs-macros.gif"/>
+ <dd><em>Vim</em></dd>
+<img src="https://github.com/reeflective/readline/blob/assets/vim-macros.gif"/>
 </details>
 
 

--- a/emacs.go
+++ b/emacs.go
@@ -1100,8 +1100,7 @@ func (rl *Shell) startKeyboardMacro() {
 // Stop saving the characters typed into the current
 // keyboard macro and store the definition.
 func (rl *Shell) endKeyboardMacro() {
-	keys := rl.Keys.Caller()
-	rl.Macros.StopRecord(keys)
+	rl.Macros.StopRecord()
 }
 
 // Re-execute the last keyboard macro defined, by making the
@@ -1128,8 +1127,7 @@ func (rl *Shell) printLastKeyboardMacro() {
 // when using Vim editing mode.
 func (rl *Shell) macroToggleRecord() {
 	if rl.Macros.Recording() {
-		keys := rl.Keys.Caller()
-		rl.Macros.StopRecord(keys)
+		rl.Macros.StopRecord()
 
 		return
 	}

--- a/history.go
+++ b/history.go
@@ -552,7 +552,8 @@ func (rl *Shell) incrementalReverseSearchHistory() {
 	rl.historyCompletion(forward, filter, regexp)
 }
 
-// Write the current line to the history if it is not empty, and clear the line buffer.
+// Write the current line to the history if it is not empty
+// (without executing it), and clear the line buffer.
 func (rl *Shell) saveLine() {
 	rl.History.Write(false)
 	rl.History.Revert()

--- a/history.go
+++ b/history.go
@@ -651,8 +651,7 @@ func (rl *Shell) acceptLineWith(infer, hold bool) {
 
 	// Without multiline support, we always return the line.
 	if rl.AcceptMultiline == nil {
-		keys := rl.Keys.Caller()
-		rl.Macros.StopRecord(keys)
+		rl.Macros.StopRecord(rl.Keys.Caller()...)
 
 		rl.Display.AcceptLine()
 		rl.History.Accept(hold, infer, nil)
@@ -663,8 +662,7 @@ func (rl *Shell) acceptLineWith(infer, hold bool) {
 	// Ask the caller if the line should be accepted
 	// as is, save the command line and accept it.
 	if rl.AcceptMultiline(*rl.line) {
-		keys := rl.Keys.Caller()
-		rl.Macros.StopRecord(keys)
+		rl.Macros.StopRecord(rl.Keys.Caller()...)
 
 		rl.Display.AcceptLine()
 		rl.History.Accept(hold, infer, nil)

--- a/internal/keymap/dispatch.go
+++ b/internal/keymap/dispatch.go
@@ -210,7 +210,7 @@ func (m *Engine) handleEscape(main bool) (bind inputrc.Bind, cmd func(), pref bo
 		// the search and return to the main keymap.
 		bind = inputrc.Bind{Action: "emacs-editing-mode"}
 
-		m.keys.Pop()
+		core.PopForce(m.keys)
 
 	case !main:
 		// When using the local keymap, we simply drop any prefixed
@@ -229,7 +229,7 @@ func (m *Engine) handleEscape(main bool) (bind inputrc.Bind, cmd func(), pref bo
 
 	// Drop the escape key in the stack
 	if main {
-		m.keys.Pop()
+		core.PopForce(m.keys)
 	}
 
 	return bind, cmd, pref

--- a/internal/macro/engine.go
+++ b/internal/macro/engine.go
@@ -45,7 +45,7 @@ func RecordKeys(eng *Engine) {
 		return
 	}
 
-	keys := eng.keys.Caller()
+	keys := core.MacroKeys(eng.keys)
 	if len(keys) == 0 {
 		return
 	}

--- a/internal/macro/engine.go
+++ b/internal/macro/engine.go
@@ -82,7 +82,7 @@ func (e *Engine) StartRecord(key rune) {
 
 // StopRecord stops using key input as part of a macro.
 // The hint section displaying the currently saved sequence is cleared.
-func (e *Engine) StopRecord(keys []rune) {
+func (e *Engine) StopRecord(keys ...rune) {
 	e.recording = false
 
 	// Remove the hint.
@@ -92,8 +92,8 @@ func (e *Engine) StopRecord(keys []rune) {
 		return
 	}
 
-	seq := strings.TrimSuffix(string(e.current), string(keys))
-	macro := inputrc.EscapeMacro(seq)
+	e.current = append(e.current, keys...)
+	macro := inputrc.EscapeMacro(string(e.current))
 
 	e.macros[e.currentKey] = macro
 	e.macros[rune(0)] = macro


### PR DESCRIPTION
- Typos in README
- Fixes to display, line words, cursor position and refresh
- Fixes to completion filtering and display
- Adapt completion insert logic with ignore-case
- Fix update cursor on init file reload
- Fixes to fixes
- Updates to README and unexport some Windows code
- Small fix to comp trimming
- Fix to dispatch
- Fixes to hint
- Fixes to history and display accept-line
- Update README demos
- Fixes to macro recording
- Fixes to macro engines
- Update README with macros
