### PR TITLE
Refresh on resize events (Linux) and fixes

### DIFF
--- a/internal/completion/group.go
+++ b/internal/completion/group.go
@@ -86,7 +86,7 @@ func (e *Engine) groupValues(comps *Values, values RawValues) (vals, noDescVals 
 		}
 
 		// Currently this is because errors are passed as completions.
-		if strings.HasPrefix(val.Value, prefix+"ERR") || strings.HasPrefix(val.Value, prefix+"_") {
+		if strings.HasPrefix(val.Value, prefix+"ERR") && val.Value == prefix+"_" {
 			if val.Description != "" && comps != nil {
 				comps.Messages.Add(color.FgRed + val.Description)
 			}

--- a/internal/core/line.go
+++ b/internal/core/line.go
@@ -337,11 +337,11 @@ func DisplayLine(l *Line, indent int) {
 
 		// Clear everything after each line, except the last.
 		if num < len(lines)-1 {
-			line += term.ClearLineAfter
+			if len(line)+indent < term.GetWidth() {
+				line += term.ClearLineAfter
+			}
 			line += "\n"
 		}
-
-		line += term.ClearLineAfter
 
 		fmt.Print(line)
 	}

--- a/internal/display/display_unix.go
+++ b/internal/display/display_unix.go
@@ -1,0 +1,31 @@
+//go:build unix
+// +build unix
+
+package display
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// WatchResize redisplays the interface on terminal resize events.
+func WatchResize(eng *Engine) chan<- bool {
+	done := make(chan bool, 1)
+
+	resizeChannel := make(chan os.Signal)
+	signal.Notify(resizeChannel, syscall.SIGWINCH)
+
+	go func() {
+		for {
+			select {
+			case <-resizeChannel:
+				eng.Refresh()
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	return done
+}

--- a/internal/display/display_windows.go
+++ b/internal/display/display_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+// +build windows
+
+package display
+
+// WatchResize redisplays the interface on terminal resize events on Windows.
+// Currently not implemented, see related issue in repo: too buggy right now.
+func WatchResize(eng *Engine) chan<- bool {
+	return make(chan<- bool)
+	// resizeChannel := core.GetTerminalResize(eng.keys)
+
+	// for {
+	// 	select {
+	// 	case <-resizeChannel:
+	// 		// Weird behavior on Windows: when there is no autosuggested line,
+	// 		// the cursor moves at the end of the completions area, if non-empty.
+	// 		// We must manually go back to the input cursor position first.
+	// 		line, _ := eng.completer.Line()
+	// 		if eng.completer.IsInserting() {
+	// 			eng.suggested = *eng.line
+	// 		} else {
+	// 			eng.suggested = eng.histories.Suggest(eng.line)
+	// 		}
+	//
+	// 		if eng.suggested.Len() <= line.Len() {
+	// 			fmt.Println(term.HideCursor)
+	//
+	// 			compRows := completion.Coordinates(eng.completer)
+	// 			if compRows <= eng.AvailableHelperLines() {
+	// 				compRows++
+	// 			}
+	//
+	// 			term.MoveCursorBackwards(term.GetWidth())
+	// 			term.MoveCursorUp(compRows)
+	// 			term.MoveCursorUp(ui.CoordinatesHint(eng.hint))
+	// 			eng.cursorHintToLineStart()
+	// 			eng.lineStartToCursorPos()
+	// 			fmt.Println(term.ShowCursor)
+	// 		}
+	//
+	// 		eng.Refresh()
+	// 	case <-done:
+	// 		return
+	// 	}
+	// }
+}

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -264,8 +264,9 @@ func (e *Engine) displayLine() {
 	core.DisplayLine(&e.suggested, e.startCols)
 
 	// Adjust the cursor if the line fits exactly in the terminal width.
-	if e.lineCol == 0 && e.cursorCol == 0 {
+	if e.lineCol == 0 {
 		fmt.Println()
+		fmt.Print(term.ClearLineAfter)
 	}
 }
 

--- a/internal/ui/hint.go
+++ b/internal/ui/hint.go
@@ -132,8 +132,7 @@ func CoordinatesHint(hint *Hint) int {
 
 	// Otherwise compute the real length/span.
 	usedY := 0
-	line := color.Strip(text)
-	lines := strings.Split(line, "\n")
+	lines := strings.Split(text, "\n")
 
 	for i, line := range lines {
 		x, y := strutil.LineSpan([]rune(line), i, 0)

--- a/readline.go
+++ b/readline.go
@@ -57,11 +57,16 @@ func (rl *Shell) Readline() (string, error) {
 	}
 	defer term.Restore(descriptor, state)
 
+	// Prompts and cursor styles
 	rl.Display.PrintPrimaryPrompt()
 	defer rl.Display.RefreshTransient()
 	defer fmt.Print(keymap.CursorStyle("default"))
 
 	rl.init()
+
+	// Terminal resize events
+	resize := display.WatchResize(rl.Display)
+	defer close(resize)
 
 	for {
 		// Whether or not the command is resolved, let the macro


### PR DESCRIPTION
- Fixes completion/hint/line display
- Redisplay interface on terminal resize events
