### PR TITLE
More reliable newline behavior && terminal low-level access

### DIFF
--- a/internal/completion/display.go
+++ b/internal/completion/display.go
@@ -78,14 +78,14 @@ func (e *Engine) cutCompletionsBelow(scanner *bufio.Scanner, maxRows int) (strin
 	for scanner.Scan() {
 		line := scanner.Text()
 		if count < maxRows-1 {
-			cropped += line + "\n"
+			cropped += line + term.NewlineReturn
 			count++
 		} else {
 			break
 		}
 	}
 
-	cropped = strings.TrimSuffix(cropped, "\n")
+	cropped = strings.TrimSuffix(cropped, term.NewlineReturn)
 
 	// Add hint for remaining completions, if any.
 	_, used := e.completionCount()
@@ -95,7 +95,7 @@ func (e *Engine) cutCompletionsBelow(scanner *bufio.Scanner, maxRows int) (strin
 		return cropped, count - 1
 	}
 
-	cropped += fmt.Sprintf("\n"+color.Dim+color.FgYellow+" %d more completion rows... (scroll down to show)"+color.Reset, remain)
+	cropped += fmt.Sprintf(term.NewlineReturn+color.Dim+color.FgYellow+" %d more completion rows... (scroll down to show)"+color.Reset, remain)
 
 	return cropped, count
 }
@@ -116,14 +116,14 @@ func (e *Engine) cutCompletionsAboveBelow(scanner *bufio.Scanner, maxRows, absPo
 		}
 
 		if count > cutAbove && count <= absPos {
-			cropped += line + "\n"
+			cropped += line + term.NewlineReturn
 			count++
 		} else {
 			break
 		}
 	}
 
-	cropped = strings.TrimSuffix(cropped, "\n")
+	cropped = strings.TrimSuffix(cropped, term.NewlineReturn)
 	count -= cutAbove + 1
 
 	// Add hint for remaining completions, if any.
@@ -134,7 +134,7 @@ func (e *Engine) cutCompletionsAboveBelow(scanner *bufio.Scanner, maxRows, absPo
 		return cropped, count - 1
 	}
 
-	cropped += fmt.Sprintf("\n"+color.Dim+color.FgYellow+" %d more completion rows... (scroll down to show)"+color.Reset, remain)
+	cropped += fmt.Sprintf(term.NewlineReturn+color.Dim+color.FgYellow+" %d more completion rows... (scroll down to show)"+color.Reset, remain)
 
 	return cropped, count
 }

--- a/internal/completion/group.go
+++ b/internal/completion/group.go
@@ -550,7 +550,7 @@ func (g *group) writeComps(eng *Engine) (comp string) {
 	}
 
 	if g.tag != "" {
-		comp += fmt.Sprintf("%s%s%s %s\n", color.Bold, color.FgYellow, g.tag, color.Reset) + term.ClearLineAfter
+		comp += fmt.Sprintf("%s%s%s %s", color.Bold, color.FgYellow, g.tag, color.Reset) + term.ClearLineAfter + term.NewlineReturn
 		eng.usedY++
 	}
 
@@ -561,7 +561,7 @@ func (g *group) writeComps(eng *Engine) (comp string) {
 		// Generate the completion string for this row (comp/aliases
 		// and/or descriptions), and apply any styles and isearch
 		// highlighting with pattern replacement,
-		comp += g.writeRow(eng, columns) + term.ClearLineAfter
+		comp += g.writeRow(eng, columns)
 
 		columns++
 		rows++
@@ -569,12 +569,6 @@ func (g *group) writeComps(eng *Engine) (comp string) {
 		if rows > g.maxY {
 			break
 		}
-	}
-
-	// Always add a newline to the group if
-	// the end if not punctuated with one.
-	if !strings.HasSuffix(strings.TrimSuffix(comp, term.ClearLineAfter), "\n") {
-		comp += "\n"
 	}
 
 	eng.usedY += rows
@@ -609,7 +603,7 @@ func (g *group) writeRow(eng *Engine, row int) (comp string) {
 		}
 	}
 
-	comp += "\r\n"
+	comp += term.ClearLineAfter + term.NewlineReturn
 
 	return
 }

--- a/internal/completion/hint.go
+++ b/internal/completion/hint.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/reeflective/readline/internal/color"
+	"github.com/reeflective/readline/internal/term"
 )
 
 func (e *Engine) hintCompletions(comps Values) {
@@ -13,18 +14,18 @@ func (e *Engine) hintCompletions(comps Values) {
 	// and only if we don't have completions.
 	if len(comps.values) == 0 || e.config.GetBool("usage-hint-always") {
 		if comps.Usage != "" {
-			hint += color.Dim + comps.Usage + color.Reset + "\n"
+			hint += color.Dim + comps.Usage + color.Reset + term.NewlineReturn
 		}
 	}
 
 	// And all further messages
-	hint += strings.Join(comps.Messages.Get(), "\n")
+	hint += strings.Join(comps.Messages.Get(), term.NewlineReturn)
 
 	if e.Matches() == 0 && hint == "" && !e.auto {
 		hint = e.hintNoMatches()
 	}
 
-	hint = strings.TrimSuffix(hint, "\n")
+	hint = strings.TrimSuffix(hint, term.NewlineReturn)
 	if hint == "" {
 		return
 	}

--- a/internal/core/line.go
+++ b/internal/core/line.go
@@ -340,7 +340,7 @@ func DisplayLine(l *Line, indent int) {
 			if len(line)+indent < term.GetWidth() {
 				line += term.ClearLineAfter
 			}
-			line += "\n"
+			line += term.NewlineReturn
 		}
 
 		fmt.Print(line)

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -33,6 +33,7 @@ type Engine struct {
 	hintRows       int
 	compRows       int
 	primaryPrinted bool
+	termFd         uintptr
 
 	// UI components
 	keys      *core.Keys
@@ -50,6 +51,7 @@ type Engine struct {
 // NewEngine is a required constructor for the display engine.
 func NewEngine(k *core.Keys, s *core.Selection, h *history.Sources, p *ui.Prompt, i *ui.Hint, c *completion.Engine, opts *inputrc.Config) *Engine {
 	return &Engine{
+		termFd:    os.Stdout.Fd(),
 		keys:      k,
 		selection: s,
 		histories: h,
@@ -143,7 +145,7 @@ func (e *Engine) AcceptLine() {
 
 	// Go below this non-suggested line and clear everything.
 	term.MoveCursorBackwards(term.GetWidth())
-	fmt.Println()
+	fmt.Print(term.NewlineReturn)
 }
 
 // RefreshTransient goes back to the first line of the input buffer
@@ -160,7 +162,7 @@ func (e *Engine) RefreshTransient() {
 	// And redisplay the transient/primary/line.
 	e.prompt.TransientPrint()
 	e.displayLine()
-	fmt.Println()
+	fmt.Print(term.NewlineReturn)
 }
 
 // CursorToLineStart moves the cursor just after the primary prompt.
@@ -179,7 +181,7 @@ func (e *Engine) CursorToLineStart() {
 func (e *Engine) CursorBelowLine() {
 	term.MoveCursorUp(e.cursorRow)
 	term.MoveCursorDown(e.lineRows)
-	fmt.Println()
+	fmt.Print(term.NewlineReturn)
 }
 
 // lineStartToCursorPos can be used if the cursor is currently
@@ -265,7 +267,7 @@ func (e *Engine) displayLine() {
 
 	// Adjust the cursor if the line fits exactly in the terminal width.
 	if e.lineCol == 0 {
-		fmt.Println()
+		fmt.Print(term.NewlineReturn)
 		fmt.Print(term.ClearLineAfter)
 	}
 }
@@ -274,7 +276,7 @@ func (e *Engine) displayLine() {
 // It assumes that the cursor is on the last line of input,
 // and goes back to this same line after displaying this.
 func (e *Engine) displayHelpers() {
-	fmt.Println()
+	fmt.Print(term.NewlineReturn)
 
 	// Recompute completions and hints if autocompletion is on.
 	e.completer.Autocomplete()
@@ -294,7 +296,7 @@ func (e *Engine) displayHelpers() {
 // AvailableHelperLines returns the number of lines available below the hint section.
 // It returns half the terminal space if we currently have less than 1/3rd of it below.
 func (e *Engine) AvailableHelperLines() int {
-	_, termHeight, _ := term.GetSize(int(os.Stdout.Fd()))
+	_, termHeight, _ := term.GetSize(int(e.termFd))
 	compLines := termHeight - e.startRows - e.lineRows - e.hintRows
 
 	if compLines < (termHeight / oneThirdTerminalHeight) {

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -257,7 +257,7 @@ func (e *Engine) displayLine() {
 	}
 
 	// Format tabs as spaces, for consistent display
-	line = strutil.FormatTabs(line)
+	line = strutil.FormatTabs(line) + term.ClearLineAfter
 
 	// And display the line.
 	e.suggested.Set([]rune(line)...)

--- a/internal/keymap/config.go
+++ b/internal/keymap/config.go
@@ -10,10 +10,20 @@ import (
 	"github.com/reeflective/readline/inputrc"
 )
 
+// readline global options specific to this library.
+var readlineOptions = map[string]interface{}{
+	"autocomplete":        false,
+	"autopairs":           false,
+	"transient-prompt":    false,
+	"history-autosuggest": false,
+	"usage-hint-always":   false,
+}
+
 // ReloadConfig parses all valid .inputrc configurations and immediately
 // updates/reloads all related settings (editing mode, variables behavior, etc.)
 func (m *Engine) ReloadConfig(opts ...inputrc.Option) (err error) {
 	// Builtin Go binds (in addition to default readline binds)
+	m.loadBuiltinOptions()
 	m.loadBuiltinBinds()
 
 	user, _ := user.Current()
@@ -57,6 +67,16 @@ func (m *Engine) ReloadConfig(opts ...inputrc.Option) (err error) {
 	}
 
 	return nil
+}
+
+// loadBuiltinOptions loads some options specific to
+// this library, if they are not loaded already.
+func (m *Engine) loadBuiltinOptions() {
+	for name, value := range readlineOptions {
+		if val := m.config.Get(name); val != nil {
+			m.config.Set(name, value)
+		}
+	}
 }
 
 // loadBuiltinBinds adds additional command mappins that are not part

--- a/internal/keymap/config.go
+++ b/internal/keymap/config.go
@@ -73,7 +73,7 @@ func (m *Engine) ReloadConfig(opts ...inputrc.Option) (err error) {
 // this library, if they are not loaded already.
 func (m *Engine) loadBuiltinOptions() {
 	for name, value := range readlineOptions {
-		if val := m.config.Get(name); val != nil {
+		if val := m.config.Get(name); val == nil {
 			m.config.Set(name, value)
 		}
 	}

--- a/internal/strutil/split.go
+++ b/internal/strutil/split.go
@@ -3,6 +3,7 @@ package strutil
 import (
 	"bytes"
 	"errors"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 )
@@ -20,6 +21,9 @@ var (
 	escapeChar        = '\\'
 	doubleEscapeChars = "$`\"\n\\"
 )
+
+// NewlineMatcher is a regular expression matching all newlines or returned newlines.
+var NewlineMatcher = regexp.MustCompile(`\r\n`)
 
 // Split splits a string according to /bin/sh's word-splitting rules. It
 // supports backslash-escapes, single-quotes, and double-quotes. Notably it does

--- a/internal/term/codes.go
+++ b/internal/term/codes.go
@@ -2,6 +2,8 @@ package term
 
 // Terminal control sequences.
 const (
+	NewlineReturn = "\r\n"
+
 	ClearLineAfter   = "\x1b[0K"
 	ClearLineBefore  = "\x1b[1K"
 	ClearLine        = "\x1b[2K"

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -7,13 +7,28 @@ import (
 	"golang.org/x/term"
 )
 
+// Those variables are very important to realine low-level code: all virtual terminal
+// escape sequences should always be sent and read through the raw terminal file, even
+// if people start using io.MultiWriters and os.Pipes involving basic IO.
+var (
+	stdoutTerm *os.File
+	stdinTerm  *os.File
+	stderrTerm *os.File
+)
+
+func init() {
+	stdoutTerm = os.Stdout
+	stdoutTerm = os.Stderr
+	stderrTerm = os.Stdin
+}
+
 // fallback terminal width when we can't get it through query.
 var defaultTermWidth = 80
 
 // GetWidth returns the width of Stdout or 80 if the width cannot be established.
 func GetWidth() (termWidth int) {
 	var err error
-	fd := int(os.Stdout.Fd())
+	fd := int(stdoutTerm.Fd())
 	termWidth, _, err = GetSize(fd)
 
 	if err != nil {
@@ -26,7 +41,7 @@ func GetWidth() (termWidth int) {
 // GetLength returns the length of the terminal
 // (Y length), or 80 if it cannot be established.
 func GetLength() int {
-	width, _, err := term.GetSize(0)
+	width, _, err := term.GetSize(int(stdoutTerm.Fd()))
 
 	if err != nil || width == 0 {
 		return defaultTermWidth

--- a/internal/ui/hint.go
+++ b/internal/ui/hint.go
@@ -86,45 +86,44 @@ func DisplayHint(hint *Hint) {
 		return
 	}
 
-	var text string
-
-	// Add the various hints.
-	if len(hint.persistent) > 0 {
-		text += string(hint.persistent) + "\n"
-	}
-
-	if len(hint.text) > 0 {
-		text += string(hint.text) + "\n"
-	}
+	text := hint.renderHint()
 
 	if strutil.RealLength(text) == 0 {
 		return
 	}
 
-	text = strings.Join(strings.Split(text, "\n"), term.ClearLineAfter+"\n")
-
-	text = "\r" + text + term.ClearLineAfter + color.Reset
+	text += term.ClearLineAfter + color.Reset
 
 	if len(text) > 0 {
 		fmt.Print(text)
 	}
 }
 
+func (h *Hint) renderHint() (text string) {
+	if len(h.persistent) > 0 {
+		text += string(h.persistent) + term.NewlineReturn
+	}
+
+	if len(h.text) > 0 {
+		text += string(h.text) + term.NewlineReturn
+	}
+
+	if strutil.RealLength(text) == 0 {
+		return
+	}
+
+	// Ensure cross-platform, real display newline.
+	text = strings.ReplaceAll(text, term.NewlineReturn, term.ClearLineAfter+term.NewlineReturn)
+
+	return text
+}
+
 // CoordinatesHint returns the number of terminal rows used by the hint.
 func CoordinatesHint(hint *Hint) int {
-	var text string
-
-	// Add the various hints.
-	if len(hint.persistent) > 0 {
-		text += string(hint.persistent) + "\n"
-	}
-
-	if len(hint.text) > 0 {
-		text += string(hint.text)
-	}
+	text := hint.renderHint()
 
 	// Nothing to do if no real text
-	text = strings.TrimSuffix(text, "\n")
+	text = strings.TrimSuffix(text, term.ClearLineAfter+term.NewlineReturn)
 
 	if strutil.RealLength(text) == 0 {
 		return 0
@@ -132,7 +131,7 @@ func CoordinatesHint(hint *Hint) int {
 
 	// Otherwise compute the real length/span.
 	usedY := 0
-	lines := strings.Split(text, "\n")
+	lines := strings.Split(text, term.ClearLineAfter)
 
 	for i, line := range lines {
 		x, y := strutil.LineSpan([]rune(line), i, 0)


### PR DESCRIPTION
- Load default options
- fix stupid
- Fix clearline after input buffer
- Change UNIX newlines with returned newlines in display (more reliable)
- Always use original terminal file descriptor for low-level cursor requests, and potentially most other virtual terminal sequences.
