### PR TITLE
dev

### DIFF
--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -2,7 +2,6 @@ package display
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/reeflective/readline/inputrc"
 	"github.com/reeflective/readline/internal/color"
@@ -33,7 +32,6 @@ type Engine struct {
 	hintRows       int
 	compRows       int
 	primaryPrinted bool
-	termFd         uintptr
 
 	// UI components
 	keys      *core.Keys
@@ -51,7 +49,6 @@ type Engine struct {
 // NewEngine is a required constructor for the display engine.
 func NewEngine(k *core.Keys, s *core.Selection, h *history.Sources, p *ui.Prompt, i *ui.Hint, c *completion.Engine, opts *inputrc.Config) *Engine {
 	return &Engine{
-		termFd:    os.Stdout.Fd(),
 		keys:      k,
 		selection: s,
 		histories: h,
@@ -296,7 +293,7 @@ func (e *Engine) displayHelpers() {
 // AvailableHelperLines returns the number of lines available below the hint section.
 // It returns half the terminal space if we currently have less than 1/3rd of it below.
 func (e *Engine) AvailableHelperLines() int {
-	_, termHeight, _ := term.GetSize(int(e.termFd))
+	termHeight := term.GetLength()
 	compLines := termHeight - e.startRows - e.lineRows - e.hintRows
 
 	if compLines < (termHeight / oneThirdTerminalHeight) {


### PR DESCRIPTION
- Load default options
- fix stupid
- Fix clearline after input buffer
- Change UNIX newlines with returned newlines in display (more reliable)
- Always use original terminal file descriptor for low-level cursor requests, and potentially most other virtual terminal sequences.
- Don't code too late in the night
