### PR TITLE
Fix typos and don't trim comments in returned buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-
 <div align="center">
   <br> <h1> Readline </h1>
 </div>
-
 
 <!-- Badges -->
 <p align="center">
@@ -39,13 +37,13 @@
 
 This library is a modern, pure Go `readline` shell implementation, with full `.inputrc` and legacy
 readline command/option support, and extended with various commands, options and tools commonly
-found in modern shells. Its architecture and completion system is heavily inspired from Z-Shell.   
+found in modern shells. Its architecture and completion system is heavily inspired from Z-Shell.
 It is used, between others, to power the [console](https://github.com/reeflective/console) library.
-
 
 ## Features
 
-### Core 
+### Core
+
 - Pure Go, almost-only standard library
 - Cross-platform (Linux / MacOS / Windows)
 - Full `.inputrc` support (all commands/options)
@@ -57,23 +55,26 @@ It is used, between others, to power the [console](https://github.com/reeflectiv
 - Support for an [arbitrary number of history sources](https://github.com/reeflective/readline/wiki/History-Sources)
 
 ### Emacs / Standard
+
 - Native Emacs commands
-- Emacs-style [macro engine](https://github.com/reeflective/readline/wiki/Macros#emacs) (not working accross multiple calls)
+- Emacs-style [macro engine](https://github.com/reeflective/readline/wiki/Macros#emacs) (not working across multiple calls)
 - Keywords [switching](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands#modifying-text) (operators, booleans, hex/binary/digit) with iterations
 - Command/mode cursor status indicator
 - Complete undo/redo history
 - Command status/arg/iterations hint display
 
 ### Vim
+
 - Near-native Vim mode
 - Vim [text objects](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands#text-objects) (code blocks, words/blank/shellwords)
-- Extended surround select/change/add fonctionality, with highlighting
+- Extended surround select/change/add functionality, with highlighting
 - Vim Visual/Operator pending mode & cursor styles indications
 - Vim Insert and Replace (once/many)
 - All Vim registers, with completion support
 - [Vim-style](https://github.com/reeflective/readline/wiki/Macros#vim) macro recording (`q<a>`) and invocation (`@<a>`)
 
 ### Interface
+
 - Support for PS1/PS2/RPROMPT/transient/tooltip [prompts](https://github.com/reeflective/readline/wiki/Prompts) (compatible with [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh))
 - Extended completion system, [keymap-based and configurable](https://github.com/reeflective/readline/wiki/Keymaps-&-Commands#completion), easy to populate & use
 - Multiple completion display styles, with color support.
@@ -82,14 +83,12 @@ It is used, between others, to power the [console](https://github.com/reeflectiv
 - Optional asynchronous autocomplete
 - Builtin & programmable [syntax highlighting](https://github.com/reeflective/readline/wiki/Syntax-Highlighting)
 
-
 ## Documentation
 
-Readline is used by the [console library](https://github.com/reeflective/console) and its [example binary](https://github.com/reeflective/console/tree/main/example). To get a grasp of the 
+Readline is used by the [console library](https://github.com/reeflective/console) and its [example binary](https://github.com/reeflective/console/tree/main/example). To get a grasp of the
 functionality provided by readline and its default configuration, install and start the binary.
 
 The documentation is available on the [repository wiki](https://github.com/reeflective/readline/wiki), for both users and developers.
-
 
 ## Showcases
 
@@ -164,7 +163,6 @@ The documentation is available on the [repository wiki](https://github.com/reefl
 <img src="https://github.com/reeflective/readline/blob/assets/vim-macros.gif"/>
 </details>
 
-
 ## Status
 
 This library is now in a release status, as it has underwent several major rewrites and is now considered mostly
@@ -172,11 +170,11 @@ feature-complete, with a solid testing suite to ensure safe and smooth operation
 New releases will be regularly pushed when bugs are found and corrected.
 
 Additionally:
-- Key dispatch/flushing, meta-key enable, etc might still contain some bugs/wrong behavior: 
+
+- Key dispatch/flushing, meta-key enable, etc might still contain some bugs/wrong behavior:
   30 years of legacy support for 3000 different terminal emulators cannot be done right by me alone.
 - Please open a PR or an issue if you face any bug, and it will be promptly resolved.
 - Don't hesitate proposing a new feature or a PR if you deem it to be useful to most users.
-
 
 ## Credits
 

--- a/completion.go
+++ b/completion.go
@@ -174,7 +174,7 @@ func (rl *Shell) viRegistersComplete() {
 	rl.startMenuComplete(rl.Buffers.Complete)
 }
 
-// In a menu completion (wether a candidate is selected or not), start incremental-search
+// In a menu completion (whether a candidate is selected or not), start incremental-search
 // (fuzzy search) on the results. Search backward incrementally for a specified string.
 // The search is case-insensitive if the search string does not have uppercase letters
 // and no numeric argument was given. The string may begin with ‘^’ to anchor the search

--- a/history.go
+++ b/history.go
@@ -573,7 +573,7 @@ func (rl *Shell) historySourcePrev() {
 	rl.History.Cycle(false)
 }
 
-// If a line is currently autoggested, make it the buffer.
+// If a line is currently auto-suggested, make it the buffer.
 func (rl *Shell) autosuggestAccept() {
 	suggested := rl.History.Suggest(rl.line)
 
@@ -585,7 +585,7 @@ func (rl *Shell) autosuggestAccept() {
 	rl.cursor.Set(len(suggested))
 }
 
-// If a line is currently autoggested, make it the buffer and execute it.
+// If a line is currently auto-suggested, make it the buffer and execute it.
 func (rl *Shell) autosuggestExecute() {
 	suggested := rl.History.Suggest(rl.line)
 
@@ -599,7 +599,7 @@ func (rl *Shell) autosuggestExecute() {
 	rl.acceptLine()
 }
 
-// Toggle line history autoggestions on/off.
+// Toggle line history autosuggestions on/off.
 func (rl *Shell) autosuggestToggle() {
 	if rl.Config.GetBool("history-autosuggest") {
 		rl.autosuggestDisable()
@@ -608,7 +608,7 @@ func (rl *Shell) autosuggestToggle() {
 	}
 }
 
-// Enable history line autoggestions.
+// Enable history line autosuggestions.
 // When enabled and if a line is suggested, forward-word commands, will
 // take the first word of the non-inserted part of this suggestion and
 // will insert it in the real input line.
@@ -618,7 +618,7 @@ func (rl *Shell) autosuggestEnable() {
 	rl.Config.Vars["history-autosuggest"] = true
 }
 
-// Disable history line autoggestions.
+// Disable history line autosuggestions.
 func (rl *Shell) autosuggestDisable() {
 	rl.History.SkipSave()
 	rl.Config.Vars["history-autosuggest"] = false

--- a/inputrc/parse.go
+++ b/inputrc/parse.go
@@ -17,23 +17,25 @@ import (
 
 // Parser is a inputrc parser.
 type Parser struct {
-	haltOnErr bool
-	strict    bool
-	name      string
-	app       string
-	term      string
-	mode      string
-	keymap    string
-	line      int
-	conds     []bool
-	errs      []error
+	haltOnErr          bool
+	strict             bool
+	trimmedBufComments bool
+	name               string
+	app                string
+	term               string
+	mode               string
+	keymap             string
+	line               int
+	conds              []bool
+	errs               []error
 }
 
 // New creates a new inputrc parser.
 func New(opts ...Option) *Parser {
 	// build parser state
 	p := &Parser{
-		line: 1,
+		line:               1,
+		trimmedBufComments: true,
 	}
 	for _, o := range opts {
 		o(p)
@@ -364,6 +366,13 @@ func WithTerm(term string) Option {
 func WithMode(mode string) Option {
 	return func(p *Parser) {
 		p.mode = mode
+	}
+}
+
+// WithTrimmedBufComments is a parser option to set trimmed buffer comments.
+func WithTrimmedBufComments(trimmedBufComments bool) Option {
+	return func(p *Parser) {
+		p.trimmedBufComments = trimmedBufComments
 	}
 }
 

--- a/inputrc/parse.go
+++ b/inputrc/parse.go
@@ -17,25 +17,23 @@ import (
 
 // Parser is a inputrc parser.
 type Parser struct {
-	haltOnErr          bool
-	strict             bool
-	trimmedBufComments bool
-	name               string
-	app                string
-	term               string
-	mode               string
-	keymap             string
-	line               int
-	conds              []bool
-	errs               []error
+	haltOnErr bool
+	strict    bool
+	name      string
+	app       string
+	term      string
+	mode      string
+	keymap    string
+	line      int
+	conds     []bool
+	errs      []error
 }
 
 // New creates a new inputrc parser.
 func New(opts ...Option) *Parser {
 	// build parser state
 	p := &Parser{
-		line:               1,
-		trimmedBufComments: true,
+		line: 1,
 	}
 	for _, o := range opts {
 		o(p)
@@ -366,13 +364,6 @@ func WithTerm(term string) Option {
 func WithMode(mode string) Option {
 	return func(p *Parser) {
 		p.mode = mode
-	}
-}
-
-// WithTrimmedBufComments is a parser option to set trimmed buffer comments.
-func WithTrimmedBufComments(trimmedBufComments bool) Option {
-	return func(p *Parser) {
-		p.trimmedBufComments = trimmedBufComments
 	}
 }
 

--- a/internal/core/line.go
+++ b/internal/core/line.go
@@ -23,7 +23,7 @@ type Tokenizer func(cursorPos int) (split []string, index int, newPos int)
 type Line []rune
 
 // Set replaces the line contents altogether with a new slice of characters.
-// If no charaters are passed, the line is thus made empty.
+// If no characters are passed, the line is thus made empty.
 func (l *Line) Set(chars ...rune) {
 	*l = chars
 }
@@ -33,7 +33,7 @@ func (l *Line) Set(chars ...rune) {
 // length of the line, nothing is inserted.
 func (l *Line) Insert(pos int, chars ...rune) {
 	for {
-		// I don't really understand why `0` is creaping in at the
+		// I don't really understand why `0` is creeping in at the
 		// end of the array but it only happens with unicode characters.
 		if len(chars) > 1 && chars[len(chars)-1] == 0 {
 			chars = chars[:len(chars)-1]

--- a/internal/history/sources.go
+++ b/internal/history/sources.go
@@ -46,7 +46,7 @@ type Sources struct {
 // NewSources is a required constructor for the history sources manager type.
 func NewSources(line *core.Line, cur *core.Cursor, hint *ui.Hint, opts *inputrc.Config) *Sources {
 	sources := &Sources{
-		// History sourcces
+		// History sources
 		list: make(map[string]Source),
 		// Line history
 		lines: make(map[string]map[int]*lineHistory),
@@ -361,12 +361,14 @@ func (h *Sources) LineAccepted() (bool, string, error) {
 
 	line := string(h.acceptLine)
 
-	// Remove all comments before returning the line to the caller.
-	comment := strings.Trim(h.config.GetString("comment-begin"), "\"")
-	commentPattern := fmt.Sprintf(`(^|\s)%s.*`, comment)
+	// Remove all comments before returning the line to the caller
+	if h.config.GetBool("trim-comments") {
+		comment := strings.Trim(h.config.GetString("comment-begin"), "\"")
+		commentPattern := fmt.Sprintf(`(^|\s)%s.*`, comment)
 
-	if commentsMatch, err := regexp.Compile(commentPattern); err == nil {
-		line = commentsMatch.ReplaceAllString(line, "")
+		if commentsMatch, err := regexp.Compile(commentPattern); err == nil {
+			line = commentsMatch.ReplaceAllString(line, "")
+		}
 	}
 
 	// Revert all state changes to all lines.

--- a/internal/history/sources.go
+++ b/internal/history/sources.go
@@ -351,25 +351,12 @@ func (h *Sources) Accept(hold, infer bool, err error) {
 // LineAccepted returns true if the user has accepted the line, signaling
 // that the shell must return from its loop. The error can be nil, but may
 // indicate a CtrlC/CtrlD style error.
-// If the input line contains any comments (as defined by the configured
-// comment sign), they will be removed before returning the line. Those
-// are nonetheless preserved when the line is saved to history sources.
 func (h *Sources) LineAccepted() (bool, string, error) {
 	if !h.accepted {
 		return false, "", nil
 	}
 
 	line := string(h.acceptLine)
-
-	// Remove all comments before returning the line to the caller
-	if h.config.GetBool("trim-comments") {
-		comment := strings.Trim(h.config.GetString("comment-begin"), "\"")
-		commentPattern := fmt.Sprintf(`(^|\s)%s.*`, comment)
-
-		if commentsMatch, err := regexp.Compile(commentPattern); err == nil {
-			line = commentsMatch.ReplaceAllString(line, "")
-		}
-	}
 
 	// Revert all state changes to all lines.
 	if h.config.GetBool("revert-all-at-newline") {

--- a/internal/keymap/config.go
+++ b/internal/keymap/config.go
@@ -86,7 +86,7 @@ func (m *Engine) loadBuiltinOptions() {
 	}
 }
 
-// loadBuiltinBinds adds additional command mappins that are not part
+// loadBuiltinBinds adds additional command mappings that are not part
 // of the standard C readline configuration: those binds therefore can
 // reference commands or keymaps only implemented/used in this library.
 func (m *Engine) loadBuiltinBinds() {

--- a/shell.go
+++ b/shell.go
@@ -26,8 +26,8 @@ import (
 type Shell struct {
 	// Core editor
 	line       *core.Line       // The input line buffer and its management methods.
-	cursor     *core.Cursor     // The cursor and its medhods.
-	selection  *core.Selection  // The selection managees various visual/pending selections.
+	cursor     *core.Cursor     // The cursor and its methods.
+	selection  *core.Selection  // The selection manages various visual/pending selections.
 	Iterations *core.Iterations // Digit arguments for repeating commands.
 	Buffers    *editor.Buffers  // buffers (Vim registers) and methods use/manage/query them.
 	Keys       *core.Keys       // Keys is in charge of reading and managing buffered user input.


### PR DESCRIPTION
- minor typo fixes
- WIP work on new option
- Remove parsing/trimming of comments in returned line
- Remove corresponding option for comments in inputrc
