### PR TITLE
Fix for backslashes being replaced by null bytes

### DIFF
--- a/inputrc/parse.go
+++ b/inputrc/parse.go
@@ -620,6 +620,10 @@ func unescapeRunes(r []rune, i, end int) string {
 	var seq []rune
 	var char0, char1, char2, char3, char4, char5 rune
 
+	if len(r) == 1 {
+		return string(r)
+	}
+
 	for ; i < end; i++ {
 		if char0 = r[i]; char0 == '\\' {
 			char1, char2, char3, char4, char5 = grab(r, i+1, end), grab(r, i+2, end), grab(r, i+3, end), grab(r, i+4, end), grab(r, i+5, end)


### PR DESCRIPTION
This PR addresses #46. While testing Sliver, we noticed that the `\` character was being consumed but not printed. Upon further investigation, it looks like backslashes were being replaced by null bytes (`\x00`). I tracked it down to the `unescapeRunes` function in `inputrc/parse.go`.

When the sequence of runes has a length of 1, the loop that reads ahead grabs zeroes for `char1` through `char5` and essentially interprets the sequence as trying to escape a null byte.

This PR returns a string representation of the sequence immediately if the length of the sequence is 1 to avoid this.