### PR TITLE
Move history save after history init

### DIFF
--- a/internal/completion/isearch.go
+++ b/internal/completion/isearch.go
@@ -162,7 +162,6 @@ func (e *Engine) updateIncrementalSearch() {
 
 	var err error
 	e.IsearchRegex, err = regexp.Compile(regexStr)
-
 	if err != nil {
 		e.hint.Set(color.FgRed + "Failed to compile i-search regexp")
 	}

--- a/readline.go
+++ b/readline.go
@@ -135,12 +135,12 @@ func (rl *Shell) init() {
 	rl.selection.Reset()
 	rl.Buffers.Reset()
 	rl.History.Reset()
-	rl.History.Save()
 	rl.Iterations.Reset()
 
 	// Some accept-* commands must fetch a specific
 	// line outright, or keep the accepted one.
 	history.Init(rl.History)
+	rl.History.Save()
 
 	// Reset/initialize user interface components.
 	rl.Hint.Reset()


### PR DESCRIPTION
This PR fixes an issue I encountered when re-executing commands from the history. Specifically, when I executed a previous command and then viewed the history immediately afterward, the history entry immediately after the executed command was blank. After doing some digging, the missing entry was still in the actual history, but the empty string was being saved in the undo history, causing it to appear as blank. 

To fix this, I moved the history save in the `init()` function to after history's init. Alternatively, the save could be deleted, but I am not sure which is preferred.

To recreate this bug yourself, you can execute the following with the `console` example application:
```
cmd1<Enter>
cmd2<Enter>
cmd3<Enter>
cmd4<Enter>
<Up>
<Up>
<Up>
<Enter> (Execute cmd2 from the history)
<Up>
<Up>
<Up> (Now you will see cmd3 is missing)
```