### PR TITLE
fix: Panic in color.Trim()

### DIFF
--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -106,6 +106,10 @@ func Trim(input string, maxPrintableLength int) string {
 		}
 	}
 
+	if maxPrintableLength > len(input) {
+		return input
+	}
+
 	// Determine the end index for limiting printable content
 	return input[:maxPrintableLength]
 }


### PR DESCRIPTION
Resolves #89 

If the new maximum available length is larger than required to support the input after taking into account ANSI escapes, just return the input as is.