### PR TITLE
fix: Handle panic in ReadKey()

### DIFF
--- a/internal/core/keys.go
+++ b/internal/core/keys.go
@@ -264,17 +264,38 @@ func (k *Keys) ReadKey() (key rune, isAbort bool) {
 		k.mutex.RUnlock()
 	}()
 
-	switch {
-	case len(k.macroKeys) > 0:
-		key = k.macroKeys[0]
-		k.macroKeys = k.macroKeys[1:]
+	for {
+		switch {
+		case len(k.macroKeys) > 0:
+			key = k.macroKeys[0]
+			k.macroKeys = k.macroKeys[1:]
+		case k.waiting:
+			buf := <-k.keysOnce
+			if len(buf) == 0 {
+				if k.eof {
+					return 0, true
+				}
+				continue
+			}
+			key = []rune(string(buf))[0]
+		default:
+			buf, err := k.readInputFiltered()
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					k.eof = true
+				}
+				return 0, true
+			}
+			if len(buf) == 0 {
+				if k.eof {
+					return 0, true
+				}
+				continue
+			}
+			key = []rune(string(buf))[0]
+		}
 
-	case k.waiting:
-		buf := <-k.keysOnce
-		key = []rune(string(buf))[0]
-	default:
-		buf, _ := k.readInputFiltered()
-		key = []rune(string(buf))[0]
+		break
 	}
 
 	// Always mark those keys as matched, so that

--- a/internal/core/keys_test.go
+++ b/internal/core/keys_test.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"io"
+	"testing"
+)
+
+type readStep struct {
+	data []byte
+	err  error
+}
+
+type stubReadCloser struct {
+	steps []readStep
+	index int
+}
+
+func (s *stubReadCloser) Read(p []byte) (int, error) {
+	if s.index >= len(s.steps) {
+		return 0, io.EOF
+	}
+
+	step := s.steps[s.index]
+	s.index++
+
+	copy(p, step.data)
+
+	return len(step.data), step.err
+}
+
+func (s *stubReadCloser) Close() error {
+	return nil
+}
+
+func TestKeysReadKeySkipsEmptyReads(t *testing.T) {
+	originalStdin := Stdin
+	Stdin = &stubReadCloser{
+		steps: []readStep{
+			{},
+			{data: []byte("x")},
+		},
+	}
+	t.Cleanup(func() {
+		Stdin = originalStdin
+	})
+
+	keys := &Keys{}
+
+	key, isAbort := keys.ReadKey()
+
+	if isAbort {
+		t.Fatal("expected ReadKey to continue after an empty read")
+	}
+
+	if key != 'x' {
+		t.Fatalf("expected key %q, got %q", 'x', key)
+	}
+}
+
+func TestKeysReadKeyReturnsAbortOnEOF(t *testing.T) {
+	originalStdin := Stdin
+	Stdin = &stubReadCloser{
+		steps: []readStep{
+			{err: io.EOF},
+		},
+	}
+	t.Cleanup(func() {
+		Stdin = originalStdin
+	})
+
+	keys := &Keys{}
+
+	key, isAbort := keys.ReadKey()
+
+	if !isAbort {
+		t.Fatal("expected ReadKey to abort on EOF")
+	}
+
+	if key != 0 {
+		t.Fatalf("expected zero key on EOF, got %q", key)
+	}
+}


### PR DESCRIPTION
Fix a panic in Vim character-search commands (f, F, t, T) when ReadKey() receives an empty read or EOF while waiting for the target character.

In that case, ReadKey() could attempt to index into an empty rune slice and panic. This surfaced downstream during interactive use.

## What changed

internal/core/Keys.ReadKey() now:
 - handles empty reads without indexing into an empty buffer
 - treats EOF as an abort condition instead of panicking
 - continues waiting when a read returns no bytes but input has not ended

## Tests

Added regression tests covering:

 - empty read followed by valid input
 - EOF returning an abort result without panicking

## Why

Vim-style motions should fail gracefully if the follow-up character is unavailable; they should never crash the shell.