### PR TITLE
fix(core): stop spinning on terminal read errors

### DIFF
--- a/emacs.go
+++ b/emacs.go
@@ -458,6 +458,9 @@ func (rl *Shell) bracketedPasteBegin() {
 		key, empty := core.PopKey(rl.Keys)
 		if empty {
 			core.WaitAvailableKeys(rl.Keys, rl.Config)
+			if rl.Keys.IsEOF() || rl.Keys.ReadError() != nil {
+				return
+			}
 			continue
 		}
 

--- a/internal/core/keys.go
+++ b/internal/core/keys.go
@@ -36,9 +36,10 @@ type Keys struct {
 	cursor    chan []byte // Cursor coordinates has been read on stdin.
 	resize    chan bool   // Resize events on Windows are sent on stdin. USED IN WINDOWS
 
-	eof   bool            // EOF has been reached.
-	cfg   *inputrc.Config // Configuration file used for meta key settings
-	mutex sync.RWMutex    // Concurrency safety
+	eof     bool            // EOF has been reached.
+	readErr error           // Non-EOF input failure, e.g. revoked tty.
+	cfg     *inputrc.Config // Configuration file used for meta key settings
+	mutex   sync.RWMutex    // Concurrency safety
 }
 
 // WaitAvailableKeys waits until an input key is either read from standard input,
@@ -71,8 +72,14 @@ func WaitAvailableKeys(keys *Keys, cfg *inputrc.Config) {
 		// We will either read keyBuf from user, or an EOF
 		// send by ourselves, because we pause reading.
 		keyBuf, err := keys.readInputFiltered()
-		if err != nil && errors.Is(err, io.EOF) {
-			keys.eof = true
+		if err != nil {
+			keys.mutex.Lock()
+			if errors.Is(err, io.EOF) {
+				keys.eof = true
+			} else if keys.readErr == nil {
+				keys.readErr = err
+			}
+			keys.mutex.Unlock()
 			return
 		}
 
@@ -107,6 +114,14 @@ func (k *Keys) IsEOF() bool {
 	defer k.mutex.RUnlock()
 
 	return k.eof
+}
+
+// ReadError returns the first non-EOF input error observed while reading keys.
+func (k *Keys) ReadError() error {
+	k.mutex.RLock()
+	defer k.mutex.RUnlock()
+
+	return k.readErr
 }
 
 // PeekKey returns the first key in the stack, without removing it.

--- a/internal/core/keys_test.go
+++ b/internal/core/keys_test.go
@@ -1,0 +1,63 @@
+package core
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/reeflective/readline/inputrc"
+)
+
+type stubReadCloser struct {
+	read func([]byte) (int, error)
+}
+
+func (s stubReadCloser) Read(p []byte) (int, error) {
+	return s.read(p)
+}
+
+func (s stubReadCloser) Close() error {
+	return nil
+}
+
+func TestWaitAvailableKeysMarksEOF(t *testing.T) {
+	original := Stdin
+	Stdin = stubReadCloser{
+		read: func([]byte) (int, error) {
+			return 0, io.EOF
+		},
+	}
+	defer func() { Stdin = original }()
+
+	keys := &Keys{}
+	WaitAvailableKeys(keys, &inputrc.Config{})
+
+	if !keys.IsEOF() {
+		t.Fatal("expected EOF to be recorded")
+	}
+	if err := keys.ReadError(); err != nil {
+		t.Fatalf("expected no non-EOF read error, got %v", err)
+	}
+}
+
+func TestWaitAvailableKeysRecordsNonEOFReadError(t *testing.T) {
+	want := errors.New("read failed")
+
+	original := Stdin
+	Stdin = stubReadCloser{
+		read: func([]byte) (int, error) {
+			return 0, want
+		},
+	}
+	defer func() { Stdin = original }()
+
+	keys := &Keys{}
+	WaitAvailableKeys(keys, &inputrc.Config{})
+
+	if keys.IsEOF() {
+		t.Fatal("expected non-EOF read failure not to be marked as EOF")
+	}
+	if err := keys.ReadError(); !errors.Is(err, want) {
+		t.Fatalf("expected read error %v, got %v", want, err)
+	}
+}

--- a/internal/core/keys_unix.go
+++ b/internal/core/keys_unix.go
@@ -3,9 +3,7 @@
 package core
 
 import (
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strconv"
 
@@ -96,7 +94,7 @@ func (k *Keys) readInputFiltered() (keys []byte, err error) {
 	buf := make([]byte, keyScanBufSize)
 
 	read, err := Stdin.Read(buf)
-	if err != nil && errors.Is(err, io.EOF) {
+	if err != nil {
 		return
 	}
 

--- a/internal/core/keys_windows.go
+++ b/internal/core/keys_windows.go
@@ -4,8 +4,6 @@
 package core
 
 import (
-	"errors"
-	"io"
 	"unsafe"
 
 	"github.com/reeflective/readline/inputrc"
@@ -72,7 +70,7 @@ func (k *Keys) readInputFiltered() (keys []byte, err error) {
 		buf := make([]byte, keyScanBufSize)
 
 		read, err := Stdin.Read(buf)
-		if err != nil && errors.Is(err, io.EOF) {
+		if err != nil {
 			return keys, err
 		}
 

--- a/readline.go
+++ b/readline.go
@@ -96,6 +96,10 @@ func (rl *Shell) Readline() (string, error) {
 		// the macro engine has fed some keys in bulk when running one.
 		core.WaitAvailableKeys(rl.Keys, rl.Config)
 
+		if err := rl.Keys.ReadError(); err != nil {
+			return "", err
+		}
+
 		// If the input is closed, we must return the line
 		// and the error so that the caller can handle it.
 		if rl.Keys.IsEOF() {


### PR DESCRIPTION
## Summary
- surface non-EOF terminal read failures from the key reader instead of treating them as empty input
- return terminal read errors from `Readline()` so callers can exit cleanly when the tty disappears
- add regression coverage for EOF and non-EOF key read failures

## Problem
When stdin starts returning a non-EOF read error, the Unix key-reading path currently ignores it and returns an empty key buffer. `WaitAvailableKeys()` then loops forever, allocating a fresh buffer each time and burning CPU in the input loop.

