### PR TITLE
Emacs backspace fix + buffered terminal output (one flush per frame)

### DIFF
--- a/internal/completion/display.go
+++ b/internal/completion/display.go
@@ -20,7 +20,7 @@ func Display(eng *Engine, maxRows int) {
 	// little more time. The engine itself is responsible for
 	// deleting those lists when it deems them useless.
 	if eng.Matches() == 0 || eng.skipDisplay {
-		fmt.Print(term.ClearLineAfter)
+		term.WriteString(term.ClearLineAfter)
 		return
 	}
 
@@ -38,7 +38,7 @@ func Display(eng *Engine, maxRows int) {
 	completions, eng.usedY = eng.cropCompletions(completions, maxRows)
 
 	if completions != "" {
-		fmt.Print(completions)
+		term.WriteString(completions)
 	}
 }
 

--- a/internal/core/api_windows.go
+++ b/internal/core/api_windows.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"syscall"
 	"unsafe"
+
+	"github.com/reeflective/readline/internal/term"
 )
 
 var (
@@ -167,6 +169,10 @@ func setConsoleCursorPosition(c *_COORD) error {
 
 // GetCursorPos returns the current cursor position on Windows.
 func (k *Keys) GetCursorPos() (x, y int) {
+	// Flush any buffered frame output so the console cursor reflects everything
+	// printed so far before we read its position.
+	term.FlushBuffer()
+
 	t := new(_CONSOLE_SCREEN_BUFFER_INFO)
 	kernel.GetConsoleScreenBufferInfo(
 		stdout,

--- a/internal/core/keys_unix.go
+++ b/internal/core/keys_unix.go
@@ -28,6 +28,11 @@ func (k *Keys) GetCursorPos() (x, y int) {
 	var cursor []byte
 	var match [][]string
 
+	// Flush any buffered frame output first: the cursor position we are about
+	// to query is only correct once the prompt printed so far is actually on
+	// screen, not still sitting in the output buffer.
+	term.FlushBuffer()
+
 	// Echo the query and wait for the main key
 	// reading routine to send us the response back.
 	fmt.Print("\x1b[6n")

--- a/internal/core/line.go
+++ b/internal/core/line.go
@@ -311,7 +311,7 @@ func DisplayLine(l *Line, indent int) {
 
 	builtLine.WriteString(color.BgDefault)
 
-	fmt.Print(builtLine.String())
+	term.WriteString(builtLine.String())
 }
 
 // CoordinatesLine returns the number of real terminal lines on which the input line spans, considering

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -1,7 +1,6 @@
 package display
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/reeflective/readline/inputrc"
@@ -82,8 +81,11 @@ func (e *Engine) PrintPrimaryPrompt() {
 
 // ClearHelpers clears the hint and completion sections below the line.
 func (e *Engine) ClearHelpers() {
+	term.BeginBuffer()
+	defer term.EndBuffer()
+
 	e.CursorBelowLine()
-	fmt.Print(term.ClearScreenBelow)
+	term.WriteString(term.ClearScreenBelow)
 
 	term.MoveCursorUp(1)
 	term.MoveCursorUp(e.lineRows)
@@ -102,6 +104,9 @@ func (e *Engine) ResetHelpers() {
 // hints, completions and some right prompts, the shell will put the
 // display at the start of the line immediately following the line.
 func (e *Engine) AcceptLine() {
+	term.BeginBuffer()
+	defer term.EndBuffer()
+
 	e.CursorToLineStart()
 
 	e.computeCoordinates(false)
@@ -110,14 +115,14 @@ func (e *Engine) AcceptLine() {
 	term.MoveCursorBackwards(term.GetWidth())
 	term.MoveCursorDown(e.lineRows)
 	term.MoveCursorForwards(e.lineCol)
-	fmt.Print(term.ClearScreenBelow)
+	term.WriteString(term.ClearScreenBelow)
 
 	// Reprint the right-side prompt if it's not a tooltip one.
 	e.prompt.RightPrint(e.lineCol, false)
 
 	// Go below this non-suggested line and clear everything.
 	term.MoveCursorBackwards(term.GetWidth())
-	fmt.Print(term.NewlineReturn)
+	term.WriteString(term.NewlineReturn)
 }
 
 // RefreshTransient goes back to the first line of the input buffer
@@ -127,6 +132,9 @@ func (e *Engine) RefreshTransient() {
 		return
 	}
 
+	term.BeginBuffer()
+	defer term.EndBuffer()
+
 	// Go to the beginning of the primary prompt.
 	e.CursorToLineStart()
 	term.MoveCursorUp(e.prompt.PrimaryUsed())
@@ -134,7 +142,7 @@ func (e *Engine) RefreshTransient() {
 	// And redisplay the transient/primary/line.
 	e.prompt.TransientPrint()
 	e.displayLine()
-	fmt.Print(term.NewlineReturn)
+	term.WriteString(term.NewlineReturn)
 }
 
 // CursorToLineStart moves the cursor just after the primary prompt.
@@ -153,7 +161,7 @@ func (e *Engine) CursorToLineStart() {
 func (e *Engine) CursorBelowLine() {
 	term.MoveCursorUp(e.cursorRow)
 	term.MoveCursorDown(e.lineRows)
-	fmt.Print(term.NewlineReturn)
+	term.WriteString(term.NewlineReturn)
 }
 
 func (e *Engine) computeCoordinates(suggested bool) {
@@ -236,8 +244,8 @@ func (e *Engine) displayLine() {
 
 	// Adjust the cursor if the line fits exactly in the terminal width.
 	if e.lineCol == 0 {
-		fmt.Print(term.NewlineReturn)
-		fmt.Print(term.ClearLineAfter)
+		term.WriteString(term.NewlineReturn)
+		term.WriteString(term.ClearLineAfter)
 	}
 }
 

--- a/internal/display/refresh.go
+++ b/internal/display/refresh.go
@@ -15,8 +15,13 @@ import (
 // Refresh recomputes and redisplays the entire readline interface, except
 // the first lines of the primary prompt when the latter is a multiline one.
 func (e *Engine) Refresh() {
+	// Buffer the whole frame and flush once, so the terminal never shows a
+	// partial repaint and we issue a single write instead of dozens.
+	term.BeginBuffer()
+	defer term.EndBuffer()
+
 	// 1. Preparation & Coordinates
-	fmt.Print(term.HideCursor)
+	term.WriteString(term.HideCursor)
 	// Go back to the first column, and if the primary prompt
 	// was not printed yet, back up to the line's beginning row.
 	term.MoveCursorBackwards(term.GetWidth())
@@ -63,10 +68,11 @@ func (e *Engine) Refresh() {
 	// CUD + clear + CUU to clean up artifacts from previous renders.
 	termHeight := term.GetLength()
 	atBottom := (e.startRows + e.lineRows) >= termHeight
+
 	if !atBottom {
 		term.MoveCursorDown(1)
 		term.MoveCursorBackwards(term.GetWidth())
-		fmt.Print(term.ClearScreenBelow)
+		term.WriteString(term.ClearScreenBelow)
 		term.MoveCursorUp(1)
 		term.MoveCursorForwards(e.lineCol)
 	}
@@ -83,7 +89,7 @@ func (e *Engine) Refresh() {
 	term.MoveCursorBackwards(term.GetWidth())
 	term.MoveCursorForwards(e.cursorCol)
 
-	fmt.Print(term.ShowCursor)
+	term.WriteString(term.ShowCursor)
 }
 
 // repaintPromptUpperLines reprints the upper lines of a multi-line prompt at
@@ -131,7 +137,7 @@ func (e *Engine) renderHelpers() {
 		return
 	}
 
-	fmt.Print(term.NewlineReturn)
+	term.WriteString(term.NewlineReturn)
 
 	// 3. Display Hints
 	ui.DisplayHint(e.hint)
@@ -190,13 +196,13 @@ func (e *Engine) ensureIndicatorSpace() {
 
 		e.startCols += indicatorWidth
 		// Print the indicator on the first line.
-		fmt.Print(indicator)
+		term.WriteString(indicator)
 	} else if e.line.Lines() > 0 && e.startCols < indicatorWidth {
 		// If the prompt is shorter than the indicator, pad with spaces
 		// to ensure the input text starts aligned with subsequent lines
 		// and isn't overwritten by the indicator.
 		padding := indicatorWidth - e.startCols
-		fmt.Printf("%*s", padding, "")
+		term.Printf("%*s", padding, "")
 
 		e.startCols = indicatorWidth
 	}
@@ -237,7 +243,7 @@ func (e *Engine) ensureInputSpace() {
 	term.MoveCursorDown(e.lineRows)
 
 	for range deficit {
-		fmt.Print(term.NewlineReturn)
+		term.WriteString(term.NewlineReturn)
 	}
 
 	e.startRows -= deficit
@@ -301,15 +307,15 @@ func (e *Engine) renderMultilineIndicators() {
 	pipe := ui.DefaultMultilineColumn
 
 	for i := 1; i <= e.line.Lines(); i++ {
-		fmt.Print("\n")
+		term.WriteString("\n")
 
 		switch {
 		case numbered:
-			fmt.Printf(color.FgBlackBright+"%d"+color.Reset+" ", i+1)
+			term.Printf(color.FgBlackBright+"%d"+color.Reset+" ", i+1)
 		case i == e.line.Lines():
 			e.prompt.SecondaryPrint()
 		default:
-			fmt.Print(pipe)
+			term.WriteString(pipe)
 		}
 
 		printedLines++

--- a/internal/keymap/cursor.go
+++ b/internal/keymap/cursor.go
@@ -1,8 +1,9 @@
 package keymap
 
 import (
-	"fmt"
 	"strings"
+
+	"github.com/reeflective/readline/internal/term"
 )
 
 // CursorStyle is the style of the cursor
@@ -58,14 +59,14 @@ func (m *Engine) PrintCursor(keymap Mode) {
 	modeSet := strings.TrimSpace(m.config.GetString(cursorOptname))
 
 	if _, valid := cursors[CursorStyle(modeSet)]; valid {
-		fmt.Print(cursors[CursorStyle(modeSet)])
+		term.WriteString(cursors[CursorStyle(modeSet)])
 		return
 	}
 
 	if defaultCur, valid := defaultCursors[keymap]; valid {
-		fmt.Print(cursors[defaultCur])
+		term.WriteString(cursors[defaultCur])
 		return
 	}
 
-	fmt.Print(cursors[cursor])
+	term.WriteString(cursors[cursor])
 }

--- a/internal/keymap/dispatch_test.go
+++ b/internal/keymap/dispatch_test.go
@@ -1,0 +1,101 @@
+package keymap
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/inputrc"
+	"github.com/reeflective/readline/internal/core"
+	"github.com/reeflective/readline/internal/strutil"
+)
+
+// builtinBindMaps returns every keymap exactly as the dispatcher sees it after
+// a default engine is built (GNU defaults + this library's builtin overlays).
+func builtinBindMaps(t *testing.T) map[string]map[string]inputrc.Bind {
+	t.Helper()
+
+	_, cfg := NewEngine(&core.Keys{}, &core.Iterations{})
+
+	return cfg.Binds
+}
+
+// collisions returns, for a keymap, the ConvertMeta key bytes that more than one
+// sequence maps to with DIFFERING binds — inputs whose exact match would depend
+// on iteration order if matchBind did not impose a deterministic order.
+func collisions(binds map[string]inputrc.Bind) map[string][]inputrc.Bind {
+	bySeq := make(map[string][]inputrc.Bind)
+
+	for sequence, bind := range binds {
+		seq := strutil.ConvertMeta([]rune(sequence))
+		bySeq[seq] = append(bySeq[seq], bind)
+	}
+
+	out := make(map[string][]inputrc.Bind)
+
+	for seq, list := range bySeq {
+		differ := false
+
+		for _, b := range list[1:] {
+			if b != list[0] {
+				differ = true
+
+				break
+			}
+		}
+
+		if differ {
+			out[seq] = list
+		}
+	}
+
+	return out
+}
+
+// TestMatchBindSortIsLoadBearing documents why matchBind must impose a
+// deterministic order: the default keymaps DO contain sequences that collapse
+// (via ConvertMeta) to the same key bytes with different actions, e.g. ESC-prefixed
+// meta bindings overlapping a self-insert. With those collisions present, dropping
+// the ordering (as a naive optimization would) makes the exact `match` depend on
+// Go's randomized map iteration — i.e. nondeterministic keybind resolution. If
+// this ever reports zero collisions, the determinism requirement can be revisited.
+func TestMatchBindSortIsLoadBearing(t *testing.T) {
+	binds := builtinBindMaps(t)[string(Emacs)]
+
+	cols := collisions(binds)
+	if len(cols) == 0 {
+		t.Fatal("expected ConvertMeta collisions in the emacs keymap; if truly none, matchBind no longer needs to order its matches")
+	}
+
+	t.Logf("emacs keymap has %d colliding key sequences whose exact match is disambiguated only by matchBind's ordering", len(cols))
+}
+
+// TestMatchBindResolvesDeterministically guards the property the ordering buys:
+// for a colliding input, matchBind must return the SAME exact match on every
+// call despite map iteration randomness. Runs many times so a regression to
+// unordered iteration would be caught.
+func TestMatchBindResolvesDeterministically(t *testing.T) {
+	eng := &Engine{}
+	binds := builtinBindMaps(t)[string(Emacs)]
+
+	cols := collisions(binds)
+	if len(cols) == 0 {
+		t.Skip("no collisions to probe")
+	}
+
+	// Pick one colliding input deterministically (smallest key bytes).
+	var probe string
+
+	for seq := range cols {
+		if probe == "" || seq < probe {
+			probe = seq
+		}
+	}
+
+	want, _ := eng.matchBind([]byte(probe), binds)
+
+	for range 64 {
+		got, _ := eng.matchBind([]byte(probe), binds)
+		if got != want {
+			t.Fatalf("matchBind(%q) is nondeterministic: got %+v, first saw %+v", probe, got, want)
+		}
+	}
+}

--- a/internal/keymap/emacs.go
+++ b/internal/keymap/emacs.go
@@ -6,8 +6,12 @@ var unescape = inputrc.Unescape
 
 // emacsKeys are the default keymaps in Emacs mode.
 var emacsKeys = map[string]inputrc.Bind{
-	unescape(`\C-D`):     {Action: "end-of-file"},
-	unescape(`\C-h`):     {Action: "backward-kill-word"},
+	unescape(`\C-D`): {Action: "end-of-file"},
+	// NOTE: \C-h is deliberately NOT overridden here. Many terminals send ^H
+	// for Backspace, and the GNU default (inputrc DefaultBinds) binds \C-h to
+	// backward-delete-char. Binding it to backward-kill-word made Backspace
+	// delete a whole word on those terminals; leaving it unset restores the
+	// standard char-delete behaviour.
 	unescape(`\C-N`):     {Action: "down-line-or-history"},
 	unescape(`\C-P`):     {Action: "up-line-or-history"},
 	unescape(`\C-x\C-b`): {Action: "vi-match"},

--- a/internal/keymap/emacs_test.go
+++ b/internal/keymap/emacs_test.go
@@ -1,0 +1,29 @@
+package keymap
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/inputrc"
+	"github.com/reeflective/readline/internal/core"
+)
+
+// TestEmacsBackspaceDeletesChar guards the \C-h binding: on many terminals
+// Backspace sends ^H, so \C-h must resolve to backward-delete-char (the GNU
+// default), not backward-kill-word, which would delete a whole word on every
+// Backspace. The emacsKeys overlay must therefore NOT override the default.
+func TestEmacsBackspaceDeletesChar(t *testing.T) {
+	keys := &core.Keys{}
+	iters := &core.Iterations{}
+
+	_, cfg := NewEngine(keys, iters)
+
+	got := cfg.Binds[string(Emacs)][inputrc.Unescape(`\C-h`)].Action
+
+	if got == "backward-kill-word" {
+		t.Fatal(`\C-h is bound to backward-kill-word: Backspace would delete a whole word on terminals that send ^H`)
+	}
+
+	if got != "backward-delete-char" {
+		t.Fatalf(`\C-h resolved to %q, want "backward-delete-char"`, got)
+	}
+}

--- a/internal/term/output.go
+++ b/internal/term/output.go
@@ -1,0 +1,108 @@
+package term
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// renderOut, when non-nil, overrides the destination for rendered terminal
+// output. It is a test seam; in production it stays nil and output goes to
+// os.Stdout, resolved at call time so that tests redirecting os.Stdout (the
+// common capture pattern) keep working. Output goes to stdout — distinct from
+// termFile (stderr), used only for terminal *queries* (size, cursor position).
+var renderOut io.Writer
+
+func out() io.Writer {
+	if renderOut != nil {
+		return renderOut
+	}
+
+	return os.Stdout
+}
+
+// Output buffering lets a whole frame (one Refresh) be coalesced into a single
+// write to the terminal instead of dozens of small writes. This removes the
+// inter-write flicker a terminal can show mid-frame and cuts write syscalls per
+// keystroke from many to one.
+//
+// All rendering happens on the readline goroutine, so this state is effectively
+// single-threaded; the mutex is a cheap guard against accidental concurrent use
+// (e.g. a stray write from another goroutine) rather than a hot contention path.
+var (
+	outMu    sync.Mutex
+	outDepth int
+	outBuf   *bufio.Writer
+)
+
+// BeginBuffer starts buffering terminal writes. Calls nest: only the outermost
+// BeginBuffer/EndBuffer pair allocates and flushes the buffer, so render
+// entrypoints can be wrapped independently without coordinating.
+func BeginBuffer() {
+	outMu.Lock()
+	defer outMu.Unlock()
+
+	outDepth++
+	if outDepth == 1 {
+		outBuf = bufio.NewWriterSize(out(), 64*1024)
+	}
+}
+
+// EndBuffer flushes and tears down the buffer when leaving the outermost frame.
+// It is safe to call unmatched (it no-ops at depth 0), so it can be deferred
+// even if BeginBuffer is on an early-return path.
+func EndBuffer() {
+	outMu.Lock()
+	defer outMu.Unlock()
+
+	if outDepth == 0 {
+		return
+	}
+
+	outDepth--
+
+	if outDepth == 0 && outBuf != nil {
+		_ = outBuf.Flush()
+		outBuf = nil
+	}
+}
+
+// FlushBuffer pushes everything buffered so far to the terminal without ending
+// the frame. It must be called before any operation that READS the terminal and
+// depends on prior output being on screen — chiefly an ESC[6n cursor-position
+// query (see GetCursorPos): otherwise the prompt would still sit in the buffer
+// and the reported cursor position would be wrong.
+func FlushBuffer() {
+	outMu.Lock()
+	defer outMu.Unlock()
+
+	if outBuf != nil {
+		_ = outBuf.Flush()
+	}
+}
+
+// WriteString writes s to the terminal: into the frame buffer when one is
+// active, otherwise straight to the output. Empty strings are dropped so callers
+// need not guard.
+func WriteString(s string) {
+	if s == "" {
+		return
+	}
+
+	outMu.Lock()
+	defer outMu.Unlock()
+
+	if outDepth > 0 && outBuf != nil {
+		_, _ = io.WriteString(outBuf, s)
+		return
+	}
+
+	_, _ = io.WriteString(out(), s)
+}
+
+// Printf formats and writes to the terminal, honouring the frame buffer.
+func Printf(format string, a ...interface{}) {
+	WriteString(fmt.Sprintf(format, a...))
+}

--- a/internal/term/output_test.go
+++ b/internal/term/output_test.go
@@ -1,0 +1,126 @@
+package term
+
+import (
+	"bytes"
+	"testing"
+)
+
+// countWriter records how many times Write was called (i.e. how many syscalls a
+// real terminal would see) and accumulates the bytes for content assertions.
+type countWriter struct {
+	writes int
+	buf    bytes.Buffer
+}
+
+func (c *countWriter) Write(p []byte) (int, error) {
+	c.writes++
+
+	return c.buf.Write(p)
+}
+
+// TestWriteStringDirect: with no active buffer, each non-empty WriteString is a
+// direct write, and empty strings are dropped.
+func TestWriteStringDirect(t *testing.T) {
+	cw := &countWriter{}
+	renderOut = cw
+
+	defer func() { renderOut = nil }()
+
+	WriteString("hello")
+	WriteString("") // dropped, no write
+	WriteString(" world")
+
+	if got := cw.buf.String(); got != "hello world" {
+		t.Fatalf("content = %q, want %q", got, "hello world")
+	}
+
+	if cw.writes != 2 {
+		t.Fatalf("direct writes = %d, want 2", cw.writes)
+	}
+}
+
+// TestBufferCoalescesToSingleWrite: a whole frame's worth of writes is held
+// until EndBuffer, then flushed as one write — the core flicker/syscall win.
+func TestBufferCoalescesToSingleWrite(t *testing.T) {
+	cw := &countWriter{}
+	renderOut = cw
+
+	defer func() { renderOut = nil }()
+
+	BeginBuffer()
+	WriteString("\x1b[?25l")
+	WriteString("prompt> ")
+	WriteString("line")
+
+	if cw.writes != 0 {
+		t.Fatalf("expected nothing on screen before EndBuffer, got %d writes", cw.writes)
+	}
+
+	EndBuffer()
+
+	if cw.writes != 1 {
+		t.Fatalf("expected a single coalesced write, got %d", cw.writes)
+	}
+
+	if got := cw.buf.String(); got != "\x1b[?25lprompt> line" {
+		t.Fatalf("content = %q", got)
+	}
+}
+
+// TestBufferNestingFlushesOnce: nested Begin/End pairs only flush at the
+// outermost End, so render entrypoints can wrap independently.
+func TestBufferNestingFlushesOnce(t *testing.T) {
+	cw := &countWriter{}
+	renderOut = cw
+
+	defer func() { renderOut = nil }()
+
+	BeginBuffer()
+	WriteString("a")
+	BeginBuffer() // nested
+	WriteString("b")
+	EndBuffer() // inner: must NOT flush
+
+	if cw.writes != 0 {
+		t.Fatalf("inner EndBuffer flushed early: %d writes", cw.writes)
+	}
+
+	WriteString("c")
+	EndBuffer() // outer: flush
+
+	if cw.writes != 1 {
+		t.Fatalf("expected one flush, got %d", cw.writes)
+	}
+
+	if got := cw.buf.String(); got != "abc" {
+		t.Fatalf("content = %q, want abc", got)
+	}
+}
+
+// TestFlushBufferMidFrame: FlushBuffer pushes what's buffered so far (e.g.
+// before an ESC[6n query) without ending the frame.
+func TestFlushBufferMidFrame(t *testing.T) {
+	cw := &countWriter{}
+	renderOut = cw
+
+	defer func() { renderOut = nil }()
+
+	BeginBuffer()
+	WriteString("prompt")
+	FlushBuffer() // the prompt must now be on screen before a cursor query
+
+	if cw.writes != 1 || cw.buf.String() != "prompt" {
+		t.Fatalf("FlushBuffer did not flush partial frame: writes=%d content=%q", cw.writes, cw.buf.String())
+	}
+
+	WriteString("line")
+	EndBuffer()
+
+	if cw.writes != 2 {
+		t.Fatalf("expected 2 writes (mid-flush + end), got %d", cw.writes)
+	}
+
+	if got := cw.buf.String(); got != "promptline" {
+		t.Fatalf("content = %q", got)
+	}
+}

--- a/internal/term/term.go
+++ b/internal/term/term.go
@@ -42,16 +42,15 @@ func GetLength() int {
 }
 
 func printf(format string, a ...interface{}) {
-	s := fmt.Sprintf(format, a...)
-	fmt.Print(s)
+	WriteString(fmt.Sprintf(format, a...))
 }
 
 // EnableBracketedPaste enables bracketed paste mode.
 func EnableBracketedPaste() {
-	fmt.Print(BracketedPasteStart)
+	WriteString(BracketedPasteStart)
 }
 
 // DisableBracketedPaste disables bracketed paste mode.
 func DisableBracketedPaste() {
-	fmt.Print(BracketedPasteEnd)
+	WriteString(BracketedPasteEnd)
 }

--- a/internal/ui/hint.go
+++ b/internal/ui/hint.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 	"sync"
 
@@ -240,7 +239,7 @@ func DisplayHint(hint *Hint) {
 
 	if hint.empty() {
 		if hint.cleanup {
-			fmt.Print(term.ClearLineAfter)
+			term.WriteString(term.ClearLineAfter)
 		}
 
 		hint.cleanup = false
@@ -257,7 +256,7 @@ func DisplayHint(hint *Hint) {
 	text += term.ClearLineAfter + color.Reset
 
 	if len(text) > 0 {
-		fmt.Print(text)
+		term.WriteString(text)
 	}
 }
 

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -111,10 +111,10 @@ func (p *Prompt) PrimaryPrint() {
 
 	// Print the various lines.
 	if prompt != "" {
-		fmt.Print(prompt)
+		term.WriteString(prompt)
 	}
 
-	fmt.Print(lastPrompt)
+	term.WriteString(lastPrompt)
 
 	// And compute coordinates
 	p.primaryRows = strings.Count(prompt, "\n")
@@ -150,7 +150,7 @@ func (p *Prompt) UpperPrint() {
 	// does not leave stale characters behind.
 	lines := strings.Split(strings.TrimSuffix(upper, "\n"), "\n")
 	for _, line := range lines {
-		fmt.Print(line + term.ClearLineAfter + term.NewlineReturn)
+		term.WriteString(line + term.ClearLineAfter + term.NewlineReturn)
 	}
 }
 
@@ -174,7 +174,7 @@ func (p *Prompt) LastPrint() {
 
 	prompt := p.formatLastPrompt(lines[len(lines)-1])
 
-	fmt.Print(prompt)
+	term.WriteString(prompt)
 
 	p.primaryCols = strutil.RealLength(prompt)
 }
@@ -206,11 +206,11 @@ func (p *Prompt) LastUsed() int {
 // which is always activated when the current input line is a multiline one.
 func (p *Prompt) SecondaryPrint() {
 	if p.secondaryF != nil {
-		fmt.Print(p.secondaryF())
+		term.WriteString(p.secondaryF())
 		return
 	}
 
-	fmt.Print(DefaultSecondaryPrompt)
+	term.WriteString(DefaultSecondaryPrompt)
 }
 
 // MultilineColumnPrint prints the multiline editor column status indicator.
@@ -227,21 +227,21 @@ func (p *Prompt) MultilineColumnPrint() {
 			fmt.Fprintf(&column, "\n"+color.FgBlackBright+"%d"+color.Reset+" ", pos+2)
 		}
 
-		fmt.Print(column.String())
+		term.WriteString(column.String())
 	case len(custom) > 0:
 		var column strings.Builder
 		for range p.line.Lines() {
 			fmt.Fprintf(&column, "\n%s\x1b[0m", custom)
 		}
 
-		fmt.Print(column.String())
+		term.WriteString(column.String())
 	case defaultCol:
 		var column strings.Builder
 		for range p.line.Lines() {
 			column.WriteString("\n" + DefaultMultilineColumn)
 		}
 
-		fmt.Print(column.String())
+		term.WriteString(column.String())
 	}
 }
 
@@ -265,9 +265,9 @@ func (p *Prompt) RightPrint(startColumn int, force bool) {
 	}
 
 	if prompt, canPrint := p.formatRightPrompt(rprompt, startColumn); canPrint {
-		fmt.Print(prompt)
+		term.WriteString(prompt)
 	} else {
-		fmt.Print(term.ClearLineAfter)
+		term.WriteString(term.ClearLineAfter)
 	}
 }
 
@@ -280,10 +280,10 @@ func (p *Prompt) TransientPrint() {
 	// Clean everything below where the prompt will be printed.
 	term.MoveCursorBackwards(term.GetWidth())
 	term.MoveCursorUp(p.primaryRows)
-	fmt.Print(term.ClearScreenBelow)
+	term.WriteString(term.ClearScreenBelow)
 
 	// And print the prompt
-	fmt.Print(p.transientF())
+	term.WriteString(p.transientF())
 }
 
 // Refreshing returns true if the prompt is currently redisplaying

--- a/readline.go
+++ b/readline.go
@@ -69,7 +69,7 @@ func (rl *Shell) Readline() (string, error) {
 	// Prompts and cursor styles
 	rl.Display.PrintPrimaryPrompt()
 	defer rl.Display.RefreshTransient()
-	defer fmt.Print(keymap.CursorStyle("default"))
+	defer term.WriteString(keymap.CursorStyle("default").String())
 
 	rl.init()
 

--- a/shell.go
+++ b/shell.go
@@ -145,7 +145,7 @@ func (rl *Shell) Printf(msg string, args ...any) (n int, err error) {
 	// and clear everything below (hints and completions).
 	rl.Display.CursorBelowLine()
 	term.MoveCursorBackwards(term.GetWidth())
-	fmt.Print(term.ClearScreenBelow)
+	term.WriteString(term.ClearScreenBelow)
 
 	// Skip a line, and print the formatted message.
 	n, err = fmt.Printf(msg+"\n", args...)
@@ -165,7 +165,7 @@ func (rl *Shell) PrintTransientf(msg string, args ...any) (n int, err error) {
 	rl.Display.CursorToLineStart()
 	term.MoveCursorBackwards(term.GetWidth())
 	term.MoveCursorUp(rl.Prompt.PrimaryUsed())
-	fmt.Print(term.ClearScreenBelow)
+	term.WriteString(term.ClearScreenBelow)
 
 	// Print the logged message.
 	n, err = fmt.Printf(msg+"\n", args...)


### PR DESCRIPTION
Three commits, all GPG-signed. Ideas adapted from / evaluated against the `moloch--/readline` fork.

## Fixes
- **`fix(keymap)`** — In emacs mode `\C-h` was overridden to `backward-kill-word`; many terminals send `^H` for Backspace, so Backspace deleted a whole *word*. Dropped the override so `\C-h` falls through to the GNU default `backward-delete-char`. Regression test asserts the resolved bind.

## Performance
- **`perf(display)`** — Buffer a whole render frame and flush it in a single write. `Refresh()` (and `AcceptLine`/`RefreshTransient`/`ClearHelpers`) previously emitted dozens of separate stdout writes per keystroke (hide cursor, moves, clears, prompt, line, highlights, helpers, show cursor); a terminal can show those partial frames as flicker, and each is a syscall. New `internal/term` buffering layer (`BeginBuffer`/`EndBuffer`/`FlushBuffer`/`WriteString`/`Printf`); all render-path `fmt.Print` sites route through it.
  - **Correctness landmine handled:** `GetCursorPos` calls `term.FlushBuffer()` before the `ESC[6n` query (unix) / console cursor read (windows), so the position is measured against on-screen output, not buffered bytes.
  - Buffering changes only *when* bytes are written, never which — the PTY golden-screen tests pass **byte-identical**. Adds buffer unit tests (coalescing, nesting, mid-frame flush).

## Test-only
- **`test(keymap)`** — Guards that `matchBind`'s ordering is load-bearing: the default emacs keymap has 15 sequences that `ConvertMeta` collapses to the same key bytes with different actions, so removing the per-keystroke sort (as the fork did) would make keybind resolution depend on map iteration order. Asserts the collisions exist and that resolution stays deterministic.

## Evaluated but NOT adopted
- **matchBind sort removal** — unsafe (nondeterministic dispatch; see the guard test) and aimed at the wrong cost (`ConvertMeta` recomputed over all binds per keystroke, not the sort).
- **Cursor-position caching** — passes the current suite (because `ensureInputSpace` maintains `startRows` across scrolls) but has an untested invalidation gap: `WatchResize` doesn't mark the cache dirty, so a terminal resize would mis-render. Not worth the #98-class risk, especially now that buffering cuts the probe's cost.

## Verification
`go build`, `go test ./...` (incl. display golden-screen + `-race`), both unix and Windows builds, and `golangci-lint run` → **0 issues**.