### PR TITLE
fix: multiline/history/completion bug batch (ported from gloathub fork review)

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,46 @@
+package readline
+
+import (
+	"maps"
+	"testing"
+)
+
+// allCommands aggregates every command set the shell registers with its keymap
+// engine (see Shell.init in shell.go). The builders only construct maps of
+// method values, so a zero Shell is enough to enumerate them.
+func allCommands() commands {
+	rl := new(Shell)
+
+	all := make(commands)
+	for _, set := range []commands{
+		rl.standardCommands(),
+		rl.viCommands(),
+		rl.historyCommands(),
+		rl.completionCommands(),
+	} {
+		maps.Copy(all, set)
+	}
+
+	return all
+}
+
+// TestArrowNavigationCommandsRegistered guards that every line/history
+// navigation action bound by the library's own default keymaps resolves to a
+// registered command. The vi-insert down-arrow binding (down-line-or-search)
+// previously resolved to nothing and was a silent no-op; this is its
+// regression guard, plus its siblings so the whole arrow-nav set stays wired.
+func TestArrowNavigationCommandsRegistered(t *testing.T) {
+	all := allCommands()
+
+	for _, action := range []string{
+		"up-line-or-search",
+		"down-line-or-search",
+		"up-line-or-history",
+		"down-line-or-history",
+		"down-line-or-select",
+	} {
+		if _, ok := all[action]; !ok {
+			t.Errorf("navigation action %q is bound in the default keymaps but has no registered command", action)
+		}
+	}
+}

--- a/completion.go
+++ b/completion.go
@@ -41,6 +41,9 @@ func (rl *Shell) completeWord() {
 		rl.startMenuComplete(rl.commandCompletion)
 
 		if rl.Config.GetBool("menu-complete-display-prefix") {
+			// Insert the prefix shared by all candidates, then display the
+			// menu without selecting one (GNU menu-complete-display-prefix).
+			rl.completer.InsertCommonPrefix()
 			return
 		}
 	}
@@ -90,6 +93,8 @@ func (rl *Shell) menuComplete() {
 
 		// Immediately select only if not asked to display first.
 		if rl.Config.GetBool("menu-complete-display-prefix") {
+			// Insert the prefix shared by all candidates before displaying.
+			rl.completer.InsertCommonPrefix()
 			return
 		}
 	}

--- a/emacs.go
+++ b/emacs.go
@@ -475,7 +475,13 @@ func (rl *Shell) bracketedPasteBegin() {
 	}
 
 	if len(sequence) > 6 {
-		rl.cursor.InsertAt([]rune(string(sequence[:len(sequence)-6]))...)
+		pasted := string(sequence[:len(sequence)-6])
+		// Terminals send \r (or \r\n) for line breaks inside a bracketed paste.
+		// Normalise them to \n, otherwise the stray carriage returns corrupt the
+		// line buffer and break multiline display and evaluation.
+		pasted = strings.ReplaceAll(pasted, "\r\n", "\n")
+		pasted = strings.ReplaceAll(pasted, "\r", "\n")
+		rl.cursor.InsertAt([]rune(pasted)...)
 	}
 }
 

--- a/emacs_test.go
+++ b/emacs_test.go
@@ -1,0 +1,52 @@
+package readline
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/internal/core"
+)
+
+// feedPaste builds a minimal shell, feeds a bracketed-paste payload terminated
+// by the end sequence, runs the paste handler, and returns the resulting line.
+func feedPaste(t *testing.T, payload string) string {
+	t.Helper()
+
+	line := new(core.Line)
+	rl := &Shell{
+		Keys:   new(core.Keys),
+		line:   line,
+		cursor: core.NewCursor(line),
+	}
+
+	// The handler consumes keys until it sees the paste-end sequence, so the
+	// terminator must be fed too — otherwise it would block waiting for input.
+	rl.Keys.Feed(false, []rune(payload+"\x1b[201~")...)
+	rl.bracketedPasteBegin()
+
+	return string(*line)
+}
+
+// TestBracketedPasteNormalizesCarriageReturns guards that pasted line breaks,
+// which terminals deliver as \r or \r\n, are stored as \n. Raw carriage
+// returns corrupt the line buffer and its multiline rendering.
+func TestBracketedPasteNormalizesCarriageReturns(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{"crlf", "a\r\nb", "a\nb"},
+		{"bare cr", "a\rb", "a\nb"},
+		{"mixed", "one\r\ntwo\rthree", "one\ntwo\nthree"},
+		{"no newline", "plain", "plain"},
+		{"already lf", "a\nb", "a\nb"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := feedPaste(t, c.payload); got != c.want {
+				t.Fatalf("paste %q => %q, want %q", c.payload, got, c.want)
+			}
+		})
+	}
+}

--- a/history.go
+++ b/history.go
@@ -60,6 +60,7 @@ func (rl *Shell) historyCommands() commands {
 		"vi-down-line-or-history":            rl.viDownLineOrHistory,
 		"up-line-or-history":                 rl.upLineOrHistory,
 		"up-line-or-search":                  rl.upLineOrSearch,
+		"down-line-or-search":                rl.downLineOrSearch,
 		"down-line-or-select":                rl.downLineOrSelect,
 		"infer-next-history":                 rl.inferNextHistory,
 		"beginning-of-buffer-or-history":     rl.beginningOfBufferOrHistory,
@@ -436,6 +437,22 @@ func (rl *Shell) upLineOrSearch() {
 		rl.cursor.LineMove(-1)
 	default:
 		rl.historySearchBackward()
+	}
+}
+
+// If the cursor is not on the last line of the buffer, move down a line.
+// Otherwise, search forward in the history for a line matching the buffer.
+// This is the symmetric counterpart of up-line-or-search; without it the
+// default vi-insert down-arrow binding resolved to an unregistered command
+// and did nothing.
+func (rl *Shell) downLineOrSearch() {
+	rl.History.SkipSave()
+
+	switch {
+	case rl.cursor.LinePos() < rl.line.Lines():
+		rl.cursor.LineMove(1)
+	default:
+		rl.historySearchForward()
 	}
 }
 

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -89,6 +89,14 @@ func Fmt(color string) string {
 // string, including all escape codes found between and immediately around
 // those characters (including surrounding 1st and 80th ones).
 func Trim(input string, maxPrintableLength int) string {
+	// A non-positive budget cannot be honoured by the slicing below (it would
+	// panic on input[:negative]); callers reach this on very narrow terminals
+	// where the available column width is smaller than the trailing padding.
+	// Treat it as "nothing fits" and return empty rather than crashing.
+	if maxPrintableLength <= 0 {
+		return ""
+	}
+
 	if len(input) < maxPrintableLength {
 		return input
 	}

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -23,3 +23,29 @@ func TestStrip(t *testing.T) {
 		})
 	}
 }
+
+func TestTrim(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"shorter than max", "abc", 10, "abc"},
+		{"exact trim", "abcdef", 3, "abc"},
+		{"zero budget", "abcdef", 0, ""},
+		// A negative budget is reachable from completion column math on a very
+		// narrow terminal (maxDisplayWidth - trailingValueLen < 0). It must not
+		// panic on input[:negative].
+		{"negative budget", "abcdef", -4, ""},
+		{"trim keeps escapes", "\x1b[31mabcdef\x1b[0m", 3, "\x1b[31mabc"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Trim(c.in, c.max); got != c.want {
+				t.Fatalf("Trim(%q, %d) = %q, want %q", c.in, c.max, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/completion/insert.go
+++ b/internal/completion/insert.go
@@ -101,6 +101,77 @@ func (e *Engine) refreshLine() {
 	}
 }
 
+// InsertCommonPrefix extends the input line with the longest prefix shared by
+// every current completion candidate, beyond what the user has already typed.
+// It implements the insertion half of the GNU readline menu-complete-display-prefix
+// option ("display the common prefix of the list of possible completions before
+// cycling"); the caller invokes it only when that option is set. When the
+// candidates share nothing past the typed prefix it is a no-op, and the menu is
+// simply displayed as before.
+func (e *Engine) InsertCommonPrefix() {
+	common := e.commonPrefix()
+
+	// Only extend the typed word; never shorten or re-case it.
+	if len([]rune(common)) <= len([]rune(e.prefix)) {
+		return
+	}
+
+	// Replace the typed prefix with the longer shared one, mirroring how
+	// acceptCandidate swaps the prefix for a full candidate value.
+	e.cursor.Move(-1 * len(e.prefix))
+	e.line.Cut(e.cursor.Pos(), e.cursor.Pos()+len(e.prefix))
+	e.cursor.InsertAt([]rune(common)...)
+
+	// Keep the engine prefix in sync so the menu highlighting and any
+	// subsequent candidate insertion stay consistent with the new word.
+	e.prefix = common
+}
+
+// commonPrefix returns the longest string that prefixes every current candidate's
+// inserted value, or "" when they share nothing (or there are no candidates).
+// The comparison is case-sensitive: candidates differing only in case stop the
+// prefix early, a conservative choice that never inserts characters not shared
+// verbatim by all candidates.
+func (e *Engine) commonPrefix() string {
+	var (
+		common string
+		seen   bool
+	)
+
+	for _, grp := range e.groups {
+		for _, row := range grp.rows {
+			for _, cand := range row {
+				if !seen {
+					common = cand.Value
+					seen = true
+
+					continue
+				}
+
+				common = commonStringPrefix(common, cand.Value)
+				if common == "" {
+					return ""
+				}
+			}
+		}
+	}
+
+	return common
+}
+
+// commonStringPrefix returns the longest rune-aligned common prefix of a and b.
+func commonStringPrefix(a, b string) string {
+	ra, rb := []rune(a), []rune(b)
+	bound := min(len(ra), len(rb))
+
+	i := 0
+	for i < bound && ra[i] == rb[i] {
+		i++
+	}
+
+	return string(ra[:i])
+}
+
 // acceptCandidate inserts the currently selected candidate into the real input line.
 func (e *Engine) acceptCandidate() {
 	cur := e.currentGroup()

--- a/internal/completion/insert_test.go
+++ b/internal/completion/insert_test.go
@@ -1,0 +1,108 @@
+package completion
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/internal/core"
+)
+
+// newPrefixEngine builds a minimal engine whose menu already holds the given
+// candidate values (spread across two groups to exercise multi-group walking),
+// with the real line containing the already-typed prefix and the cursor at its
+// end -- the state completeWord/menuComplete are in when the display-prefix
+// option fires.
+func newPrefixEngine(typed string, values ...string) (*Engine, *core.Line) {
+	l := core.Line([]rune(typed))
+	line := &l
+	cur := core.NewCursor(line)
+	cur.Set(line.Len())
+
+	var groups []*group
+
+	for i, v := range values {
+		// Alternate candidates between two groups so commonPrefix must walk
+		// more than one group and more than one row.
+		gi := i % 2
+		for len(groups) <= gi {
+			groups = append(groups, &group{})
+		}
+
+		groups[gi].rows = append(groups[gi].rows, []Candidate{{Value: v}})
+	}
+
+	e := &Engine{
+		line:   line,
+		cursor: cur,
+		prefix: typed,
+		groups: groups,
+	}
+
+	return e, line
+}
+
+func TestCommonStringPrefix(t *testing.T) {
+	cases := []struct{ a, b, want string }{
+		{"foobar", "foobaz", "fooba"},
+		{"foo", "foobar", "foo"},
+		{"abc", "xyz", ""},
+		{"", "foo", ""},
+		{"café", "cafard", "caf"}, // rune-aligned, must not split the 'é'
+	}
+
+	for _, c := range cases {
+		if got := commonStringPrefix(c.a, c.b); got != c.want {
+			t.Errorf("commonStringPrefix(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestInsertCommonPrefix(t *testing.T) {
+	t.Run("extends to shared prefix", func(t *testing.T) {
+		e, line := newPrefixEngine("foo", "foobar", "foobaz", "foobat")
+		e.InsertCommonPrefix()
+
+		if got := string(*line); got != "fooba" {
+			t.Fatalf("line = %q, want %q", got, "fooba")
+		}
+
+		if e.prefix != "fooba" {
+			t.Fatalf("engine prefix = %q, want %q", e.prefix, "fooba")
+		}
+
+		if e.cursor.Pos() != 5 {
+			t.Fatalf("cursor = %d, want 5 (end of extended word)", e.cursor.Pos())
+		}
+	})
+
+	t.Run("no shared prefix beyond typed is a no-op", func(t *testing.T) {
+		e, line := newPrefixEngine("f", "foo", "fbar")
+		e.InsertCommonPrefix()
+
+		// "foo" and "fbar" share only "f", which equals the typed prefix.
+		if got := string(*line); got != "f" {
+			t.Fatalf("line = %q, want unchanged %q", got, "f")
+		}
+
+		if e.prefix != "f" {
+			t.Fatalf("engine prefix = %q, want unchanged %q", e.prefix, "f")
+		}
+	})
+
+	t.Run("single candidate extends fully", func(t *testing.T) {
+		e, line := newPrefixEngine("re", "readline")
+		e.InsertCommonPrefix()
+
+		if got := string(*line); got != "readline" {
+			t.Fatalf("line = %q, want %q", got, "readline")
+		}
+	})
+
+	t.Run("no candidates is a no-op", func(t *testing.T) {
+		e, line := newPrefixEngine("foo")
+		e.InsertCommonPrefix()
+
+		if got := string(*line); got != "foo" {
+			t.Fatalf("line = %q, want unchanged %q", got, "foo")
+		}
+	})
+}

--- a/internal/core/cursor.go
+++ b/internal/core/cursor.go
@@ -246,15 +246,20 @@ func (c *Cursor) LineMove(lines int) {
 		return
 	}
 
+	// Each step lands the cursor at the target column, or at the end of a
+	// shorter line (on its trailing newline). We deliberately do NOT clamp off
+	// that newline here: LineMove is keymap-agnostic, and the per-command
+	// post-step in Shell.execute already applies CheckCommand in vi-command
+	// mode and CheckAppend otherwise. Clamping here as well double-applied the
+	// command-mode rule, leaving the cursor one column short of the line end in
+	// emacs and vi-insert modes.
 	if lines < 0 {
 		for range -lines {
 			c.moveLineUp()
-			c.CheckCommand()
 		}
 	} else {
 		for range lines {
 			c.moveLineDown()
-			c.CheckCommand()
 		}
 	}
 }

--- a/internal/core/cursor_test.go
+++ b/internal/core/cursor_test.go
@@ -762,6 +762,85 @@ func TestCursor_LineMove(t *testing.T) {
 	}
 }
 
+// TestCursor_LineMove_LandsAtLineEnd is the regression guard for the multiline
+// off-by-one: moving onto a shorter (non-empty) line must leave the cursor at
+// that line's end (its trailing newline = the append position), not one column
+// short of it. LineMove used to apply CheckCommand on every step, which clamped
+// the cursor off the newline even for emacs/vi-insert, where end-of-line is a
+// valid position.
+func TestCursor_LineMove_LandsAtLineEnd(t *testing.T) {
+	// indices: a0 b1 c2 d3 e4 f5 \n6 x7 \n8 g9 h10 i11 j12 k13 l14
+	line := Line("abcdef\nx\nghijkl")
+
+	// On line 0, column 5 ('f'); move down onto the 1-char line "x".
+	c := &Cursor{line: &line, pos: 5, mark: -1}
+	c.LineMove(1)
+
+	// End of "x" is the trailing newline at index 8 (append position).
+	if c.Pos() != 8 {
+		t.Fatalf("down onto short line: pos %d, want 8 (end of line, not one short)", c.Pos())
+	}
+
+	if c.LinePos() != 1 {
+		t.Fatalf("down onto short line: line %d, want 1", c.LinePos())
+	}
+}
+
+// TestCursor_LineMove_ModeClampContract documents the division of labour:
+// LineMove leaves the cursor at the end-of-line position, and the caller's
+// post-step check decides whether that is allowed. Shell.execute applies
+// CheckAppend in emacs/vi-insert (end-of-line kept) and CheckCommand in
+// vi-command (clamped onto the last char).
+func TestCursor_LineMove_ModeClampContract(t *testing.T) {
+	line := Line("abcdef\nx\nghijkl")
+
+	// emacs / vi-insert: CheckAppend keeps the end-of-line position.
+	emacs := &Cursor{line: &line, pos: 5, mark: -1}
+	emacs.LineMove(1)
+	emacs.CheckAppend()
+
+	if emacs.Pos() != 8 {
+		t.Fatalf("emacs post-move: pos %d, want 8 (end of line kept)", emacs.Pos())
+	}
+
+	// vi-command: CheckCommand clamps off the newline onto 'x'.
+	vicmd := &Cursor{line: &line, pos: 5, mark: -1}
+	vicmd.LineMove(1)
+	vicmd.CheckCommand()
+
+	if vicmd.Pos() != 7 {
+		t.Fatalf("vi-command post-move: pos %d, want 7 (clamped onto last char)", vicmd.Pos())
+	}
+}
+
+// TestCursor_LineMove_StickyColumn checks that vertical motion across lines that
+// are all long enough preserves the column, and a down-then-up round trip
+// returns to the starting position.
+func TestCursor_LineMove_StickyColumn(t *testing.T) {
+	// Three equal-length lines: a0..f5 \n6 g7..l12 \n13 m14..r19
+	line := Line("abcdef\nghijkl\nmnopqr")
+
+	c := &Cursor{line: &line, pos: 3, mark: -1} // line 0, column 3 ('d')
+
+	c.LineMove(1)
+
+	if c.Pos() != 10 { // line 1, column 3 ('j')
+		t.Fatalf("down one: pos %d, want 10", c.Pos())
+	}
+
+	c.LineMove(1)
+
+	if c.Pos() != 17 { // line 2, column 3 ('p')
+		t.Fatalf("down two: pos %d, want 17", c.Pos())
+	}
+
+	c.LineMove(-2)
+
+	if c.Pos() != 3 { // back to start
+		t.Fatalf("round trip up: pos %d, want 3", c.Pos())
+	}
+}
+
 func TestCursor_OnEmptyLine(t *testing.T) {
 	type fields struct {
 		pos  int

--- a/internal/history/sources.go
+++ b/internal/history/sources.go
@@ -310,9 +310,14 @@ func (h *Sources) Write(infer bool) {
 			continue
 		}
 
-		// Don't write it if the history source has reached
-		// the maximum number of lines allowed (inputrc)
-		if h.maxEntries == 0 || h.maxEntries >= history.Len() {
+		// Don't write it if the history source has reached the maximum
+		// number of lines allowed (inputrc history-size). maxEntries <= 0
+		// means unlimited (the in-memory default is -1); a positive cap
+		// stops appending once the source is full. The previous condition
+		// was inverted -- it skipped every write while the source was still
+		// under the cap, so any configured history-size disabled writing
+		// entirely.
+		if h.maxEntries > 0 && history.Len() >= h.maxEntries {
 			continue
 		}
 

--- a/internal/history/sources_test.go
+++ b/internal/history/sources_test.go
@@ -1,0 +1,85 @@
+package history
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/internal/core"
+)
+
+// newTestSources builds a minimal Sources backed by a single in-memory source,
+// enough to exercise Write's cap logic without a full shell.
+func newTestSources(maxEntries int) (*Sources, *memory, *core.Line) {
+	line := new(core.Line)
+	mem := new(memory)
+
+	src := &Sources{
+		line:       line,
+		list:       map[string]Source{defaultSourceName: mem},
+		names:      []string{defaultSourceName},
+		maxEntries: maxEntries,
+	}
+
+	return src, mem, line
+}
+
+// writeLine sets the working line and writes it to history.
+func writeLine(src *Sources, line *core.Line, text string) {
+	*line = core.Line([]rune(text))
+
+	src.Write(false)
+}
+
+// TestWriteUnlimitedPersists guards the default (history-size unset -> -1):
+// every distinct line must be written.
+func TestWriteUnlimitedPersists(t *testing.T) {
+	src, mem, line := newTestSources(-1)
+
+	writeLine(src, line, "one")
+	writeLine(src, line, "two")
+	writeLine(src, line, "three")
+
+	if mem.Len() != 3 {
+		t.Fatalf("unlimited history wrote %d lines, want 3", mem.Len())
+	}
+}
+
+// TestWriteUnderCapPersists is the direct regression guard for the inverted
+// condition: with a positive cap and the source still under it, writes MUST
+// land. The old `maxEntries >= Len()` skipped them all.
+func TestWriteUnderCapPersists(t *testing.T) {
+	src, mem, line := newTestSources(5)
+
+	writeLine(src, line, "one")
+	writeLine(src, line, "two")
+
+	if mem.Len() != 2 {
+		t.Fatalf("capped history under the limit wrote %d lines, want 2 (inverted-condition regression)", mem.Len())
+	}
+}
+
+// TestWriteStopsAtCap verifies the cap is actually enforced: once the source
+// holds maxEntries lines, further distinct lines are not appended.
+func TestWriteStopsAtCap(t *testing.T) {
+	src, mem, line := newTestSources(2)
+
+	writeLine(src, line, "one")
+	writeLine(src, line, "two")
+	writeLine(src, line, "three") // should be refused: already at cap
+
+	if mem.Len() != 2 {
+		t.Fatalf("history grew to %d lines past its cap of 2", mem.Len())
+	}
+}
+
+// TestWriteZeroMaxIsUnlimited documents that maxEntries == 0 is treated as
+// unlimited (writes happen), matching the `> 0` guard.
+func TestWriteZeroMaxIsUnlimited(t *testing.T) {
+	src, mem, line := newTestSources(0)
+
+	writeLine(src, line, "one")
+	writeLine(src, line, "two")
+
+	if mem.Len() != 2 {
+		t.Fatalf("maxEntries==0 wrote %d lines, want 2 (should be unlimited)", mem.Len())
+	}
+}


### PR DESCRIPTION
Batch of fixes surfaced while reviewing the `gloathub/go-readline` fork's commits-ahead. Each fix is paired with a regression test; the fork's remaining commits were either already implemented in our tree, opinionated default/API changes we declined, or GNU-deviating behavior we keep faithful.

## Fixes

- **`fix(history)`: write history again when history-size is set** — `Sources.Write`'s cap guard was inverted (`maxEntries >= Len()`), so any positive `history-size` skipped *every* write. The in-memory source does no trimming of its own, so this guard was the only cap. Corrected to `maxEntries > 0 && Len() >= maxEntries`.
- **`fix(history)`: make vi-insert down-arrow navigate again** — the default vi-insert keymap binds the down arrow to `down-line-or-search`, but no such command was registered (only `up-line-or-search` and the unrelated `down-line-or-select`), so the key did nothing. Added the symmetric `downLineOrSearch`.
- **`fix(color)`: guard `Trim` against a non-positive budget** — `Trim` ended in `input[:n]` and panicked on a negative budget, reachable from completion column math on very narrow terminals. Now returns empty for a non-positive budget, guarding both call sites at the source.
- **`fix(emacs)`: normalise carriage returns in bracketed paste** — terminals deliver pasted line breaks as `\r`/`\r\n`; inserting them raw corrupted the line buffer and multiline rendering. Converted to `\n` before insertion.
- **`fix(core)`: stop `LineMove` landing one column short of line end** — `LineMove` applied `CheckCommand` every step, clamping the cursor off a line's trailing newline even in emacs/vi-insert. Since every caller already routes through `Shell.execute` (which applies the keymap-aware check), this double-applied the command-mode rule. Dropped the in-loop clamp.

## Feature (opt-in, no API/default change)

- **`feat(completion)`: insert common prefix for `menu-complete-display-prefix`** — the option was half-implemented (menu shown, shared prefix never inserted). Completes the GNU-documented semantics. Only runs when the option is set (off by default); `InsertCommonPrefix` is a method on the internal completion engine, so no public API change.

## Testing

New tests cover each fix; the `LineMove` change was verified to fail against the old code before the fix. Full suite (incl. the display golden-screen tests), `go vet`, and `golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)