### PR TITLE
feat(emacs): add skip-csi-sequence command

### DIFF
--- a/emacs.go
+++ b/emacs.go
@@ -60,6 +60,7 @@ func (rl *Shell) standardCommands() commands {
 		"tab-insert":                   rl.tabInsert,
 		"self-insert":                  rl.selfInsert,
 		"bracketed-paste-begin":        rl.bracketedPasteBegin,
+		"skip-csi-sequence":            rl.skipCsiSequence,
 		"transpose-chars":              rl.transposeChars,
 		"transpose-words":              rl.transposeWords,
 		"shell-transpose-words":        rl.shellTransposeWords,
@@ -482,6 +483,37 @@ func (rl *Shell) bracketedPasteBegin() {
 		pasted = strings.ReplaceAll(pasted, "\r\n", "\n")
 		pasted = strings.ReplaceAll(pasted, "\r", "\n")
 		rl.cursor.InsertAt([]rune(pasted)...)
+	}
+}
+
+// skipCsiSequence consumes the remainder of a CSI escape sequence (the GNU
+// readline skip-csi-sequence command). Terminals encode many special keys as
+// "ESC [" followed by parameter/intermediate bytes (0x20-0x3F) and a single
+// final byte (0x40-0x7E) -- e.g. F5 is "\e[15~", Shift-Tab is "\e[Z". When such
+// a key has no binding, its trailing bytes would otherwise be self-inserted as
+// stray characters. Bound to "\e[", this command catches any CSI sequence that
+// no longer/exact binding claimed and swallows the rest of it, so unrecognised
+// keys do nothing.
+//
+// It is intentionally left unbound by default (as in GNU readline); enable it
+// from inputrc by binding the sequence "\e[" to the skip-csi-sequence command.
+func (rl *Shell) skipCsiSequence() {
+	rl.History.SkipSave()
+
+	// Whatever the dispatcher already consumed of the sequence, drain the rest:
+	// keep popping parameter/intermediate bytes, and stop once we consume the
+	// terminating byte (the final byte, or any non-CSI byte). The keys of a CSI
+	// sequence arrive in a single terminal read, so they are already buffered;
+	// if the buffer empties we simply stop rather than block on a partial one.
+	for {
+		key, empty := core.PopKey(rl.Keys)
+		if empty {
+			return
+		}
+
+		if key < 0x20 || key >= 0x40 {
+			return
+		}
 	}
 }
 

--- a/emacs_test.go
+++ b/emacs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/reeflective/readline/internal/core"
+	"github.com/reeflective/readline/internal/history"
 )
 
 // feedPaste builds a minimal shell, feeds a bracketed-paste payload terminated
@@ -46,6 +47,54 @@ func TestBracketedPasteNormalizesCarriageReturns(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := feedPaste(t, c.payload); got != c.want {
 				t.Fatalf("paste %q => %q, want %q", c.payload, got, c.want)
+			}
+		})
+	}
+}
+
+// drainKeys pops everything remaining in the key buffer and returns it.
+func drainKeys(rl *Shell) string {
+	var b []byte
+
+	for {
+		key, empty := core.PopKey(rl.Keys)
+		if empty {
+			return string(b)
+		}
+
+		b = append(b, key)
+	}
+}
+
+// TestSkipCsiSequence drives skip-csi-sequence over the bytes that remain after
+// the dispatcher has matched the leading "\e[": it must swallow the parameter
+// bytes and the single final byte, while leaving any following keystrokes
+// untouched.
+func TestSkipCsiSequence(t *testing.T) {
+	cases := []struct {
+		name     string
+		feed     string // bytes left in the buffer after "\e[" was matched
+		wantLeft string // what must remain unconsumed afterwards
+	}{
+		{"function key params and final", "15~", ""},
+		{"single final byte", "Z", ""},
+		{"modified arrow with params", "1;5D", ""},
+		{"stops at final, keeps following keys", "15~abc", "abc"},
+		{"empty buffer is a no-op", "", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rl := &Shell{Keys: new(core.Keys), History: &history.Sources{}}
+
+			if c.feed != "" {
+				rl.Keys.Feed(false, []rune(c.feed)...)
+			}
+
+			rl.skipCsiSequence()
+
+			if got := drainKeys(rl); got != c.wantLeft {
+				t.Fatalf("skip of %q left %q, want %q", c.feed, got, c.wantLeft)
 			}
 		})
 	}


### PR DESCRIPTION
Implements the remaining command from #5: `skip-csi-sequence` (the GNU readline command name; issue text had it transposed as "csi-skip-sequence").

## What it does

Terminals encode special keys (Home, End, function keys, modified arrows) as CSI sequences — `ESC [` followed by parameter/intermediate bytes (`0x20`–`0x3F`) and a single final byte (`0x40`–`0x7E`). A key with no explicit binding would otherwise have its trailing bytes (`15~`, `Z`, `1;5D`, …) self-inserted as stray characters.

`skip-csi-sequence` drains the remainder of such a sequence so unrecognized keys do nothing. Bound to `\e[`, it's the fallback for any CSI sequence no longer/exact binding claims; the dispatcher's longest-match means arrow keys (`\e[A`) etc. still win.

Note: it is **not** equivalent to zsh's `self-insert-unmeta` (as the issue's parenthetical suggested) — that *inserts* a meta-stripped key, whereas this *discards* an unrecognized sequence.

## Scope

- **Unbound by default**, matching GNU readline (`inputrc/bind.go` already carries `// skip-csi-sequence (not bound)` in every keymap). Enable via inputrc: `"\e[": skip-csi-sequence`.
- **No public API change** — it's a keymap command, registered in `standardCommands`.
- No default-behavior change.

## Testing

`TestSkipCsiSequence` covers params+final, bare final byte, modified-arrow params, stops-at-final-while-keeping-following-keys, and the empty no-op. Full suite, `go vet`, and `golangci-lint` clean.

Wiki (separate repo) documents both `skip-csi-sequence` and `bracketed-paste-begin` in Keymaps & Commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)