### PR TITLE
test(display): deflake async PTY tests (widen screen-wait timeout)

### DIFF
--- a/internal/display/pty_harness_test.go
+++ b/internal/display/pty_harness_test.go
@@ -388,7 +388,14 @@ func (c *console) screen() string {
 
 // screenWaitTimeout bounds how long the screen-polling helpers wait before
 // failing the test. Every call site used the same value, so it lives here.
-const screenWaitTimeout = 3 * time.Second
+//
+// The pollers return the instant the awaited content appears, so this ceiling
+// never slows a passing test -- it only caps how long we wait before declaring
+// failure. It is deliberately generous: under `go test -race` on a loaded CI
+// runner the whole PTY/render pipeline is starved (race instrumentation adds
+// several-fold overhead), and a tight bound turns that into spurious timeouts
+// for the async-refresh tests (locally they settle in well under 2s).
+const screenWaitTimeout = 15 * time.Second
 
 // waitForScreen polls until the rendered screen contains substr, or fails the
 // test on timeout. It returns the (last) screen contents either way.


### PR DESCRIPTION
## Problem

The `Go` workflow failed on the `master` push for #107 (the v1.2.2 merge):

```
completion_test.go:28: timed out waiting for "alpha" on screen
--- FAIL: TestAsyncRefreshCompletions (3.02s)
```

This is **unrelated to the merged change** (the skip-csi-sequence command). It's a flaky timeout in the PTY-based async-refresh test: under `go test -race` on a loaded GitHub runner, the PTY/render pipeline is starved (race instrumentation adds several-fold overhead), and the shared **3s** `screenWaitTimeout` was too tight for tests that wait on a background goroutine growing the completion menu. The same code passed on the PR run; locally the test settles in well under 2s.

## Fix

Raise `screenWaitTimeout` (the shared PTY screen-poll ceiling) from 3s to **15s**. The pollers return the instant the awaited content appears, so a larger ceiling **never slows a passing test** — it only caps how long we wait before declaring failure. No production code is touched.

## Verification

- `TestAsyncRefreshCompletions` now completes in ~0.4s under `-race`.
- Ran the full `internal/display` suite under `-race` 5× — all green (~9s each).
- `go vet` and `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)