### PR TITLE
ci: bump checkout and setup-go off deprecated Node 20

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 
@@ -37,10 +37,10 @@ jobs:
     runs-on: windows-latest 
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version-file: go.mod
 


### PR DESCRIPTION
The runner warned that several actions still run on Node 20 (forced to Node 24 on 2026-06-16, runtime removed 2026-09-16). Bump the first-party actions it flagged to their current Node 24 majors:

- `actions/checkout` v4 → **v6** (go.yml ×2, codeql.yml, dependency-review.yml, codacy.yml)
- `actions/setup-go` v5 → **v6** (go.yml ×2)

**Left as-is:**
- `codecov/codecov-action@v4` (also Node 20) — overlaps an in-progress change to the coverage-upload step; will be bumped to v5 as part of that rework, to avoid a conflict.
- `github/codeql-action@v3` and `actions/dependency-review-action@v4` — not flagged (maintained on Node 24 within their current majors).
- `codacy/codacy-analysis-cli-action` — SHA-pinned Docker action, not Node-based.

Version-string changes only; the PR's own checks validate the new action majors before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)