### PR TITLE
fix(history): return an error from memory.GetLine on out-of-range index

### DIFF
--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -45,8 +45,12 @@ func (h *memory) Write(s string) (int, error) {
 
 // GetLine returns a line from history.
 func (h *memory) GetLine(i int) (string, error) {
-	if len(h.items) == 0 {
-		return "", nil
+	if i < 0 {
+		return "", errNegativeIndex
+	}
+
+	if i >= len(h.items) {
+		return "", errOutOfRangeIndex
 	}
 
 	return h.items[i], nil

--- a/internal/history/sources_test.go
+++ b/internal/history/sources_test.go
@@ -83,3 +83,20 @@ func TestWriteZeroMaxIsUnlimited(t *testing.T) {
 		t.Fatalf("maxEntries==0 wrote %d lines, want 2 (should be unlimited)", mem.Len())
 	}
 }
+
+// TestMemoryGetLineOutOfRange guards memory.GetLine against an index past the
+// end of the buffer: it must return an error like the file source does, not
+// panic with "index out of range". History navigation (e.g. down-arrow at the
+// newest entry) can ask for position Len().
+func TestMemoryGetLineOutOfRange(t *testing.T) {
+	mem := new(memory)
+	mem.Write("test")
+
+	if _, err := mem.GetLine(mem.Len()); err == nil {
+		t.Fatalf("GetLine(%d) on a %d-line history returned nil error, want out-of-range error", mem.Len(), mem.Len())
+	}
+
+	if _, err := mem.GetLine(-1); err == nil {
+		t.Fatalf("GetLine(-1) returned nil error, want negative-index error")
+	}
+}


### PR DESCRIPTION
Fixes #110.

`memory.GetLine` only guards the empty-history case and then indexes `h.items[i]` directly, so any index past the end panics. History navigation reaches that index: pressing Down at the newest entry asks for position `Len()`, which gives `index out of range [1] with length 1` on a single-entry history (the panic in the linked issue, reproducible in vi-insert mode).

The file-backed source (`fileHistory.GetLine`) already handles this by returning `errNegativeIndex` / `errOutOfRangeIndex`, and every caller treats a `GetLine` error as recoverable. This change makes the in-memory source follow the same contract instead of panicking.

Added a regression test covering the out-of-range and negative-index cases.
