### PR TITLE
Add a bracketed paste transformer hook

### DIFF
--- a/emacs.go
+++ b/emacs.go
@@ -476,14 +476,25 @@ func (rl *Shell) bracketedPasteBegin() {
 	}
 
 	if len(sequence) > 6 {
-		pasted := string(sequence[:len(sequence)-6])
-		// Terminals send \r (or \r\n) for line breaks inside a bracketed paste.
-		// Normalise them to \n, otherwise the stray carriage returns corrupt the
-		// line buffer and break multiline display and evaluation.
-		pasted = strings.ReplaceAll(pasted, "\r\n", "\n")
-		pasted = strings.ReplaceAll(pasted, "\r", "\n")
-		rl.cursor.InsertAt([]rune(pasted)...)
+		rl.insertPastedText(string(sequence[:len(sequence)-6]))
 	}
+}
+
+func (rl *Shell) insertPastedText(text string) {
+	// Terminals send \r (or \r\n) for line breaks inside a bracketed paste.
+	// Normalise them to \n, otherwise the stray carriage returns corrupt the
+	// line buffer and break multiline display and evaluation.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+
+	if rl.PasteTransformer != nil {
+		text = rl.PasteTransformer(text)
+	}
+	if text == "" {
+		return
+	}
+
+	rl.cursor.InsertAt([]rune(text)...)
 }
 
 // skipCsiSequence consumes the remainder of a CSI escape sequence (the GNU

--- a/emacs_test.go
+++ b/emacs_test.go
@@ -12,12 +12,19 @@ import (
 func feedPaste(t *testing.T, payload string) string {
 	t.Helper()
 
+	return feedPasteWithTransformer(t, payload, nil)
+}
+
+func feedPasteWithTransformer(t *testing.T, payload string, transformer func(string) string) string {
+	t.Helper()
+
 	line := new(core.Line)
 	rl := &Shell{
 		Keys:   new(core.Keys),
 		line:   line,
 		cursor: core.NewCursor(line),
 	}
+	rl.SetPasteTransformer(transformer)
 
 	// The handler consumes keys until it sees the paste-end sequence, so the
 	// terminator must be fed too — otherwise it would block waiting for input.
@@ -49,6 +56,30 @@ func TestBracketedPasteNormalizesCarriageReturns(t *testing.T) {
 				t.Fatalf("paste %q => %q, want %q", c.payload, got, c.want)
 			}
 		})
+	}
+}
+
+func TestBracketedPasteTransformer(t *testing.T) {
+	got := feedPasteWithTransformer(t, "a\r\nb", func(text string) string {
+		if text != "a\nb" {
+			t.Fatalf("transformer saw %q, want normalized text", text)
+		}
+
+		return "rewritten"
+	})
+
+	if got != "rewritten" {
+		t.Fatalf("transformed paste = %q, want rewritten", got)
+	}
+}
+
+func TestBracketedPasteTransformerCanDropText(t *testing.T) {
+	got := feedPasteWithTransformer(t, "secret", func(string) string {
+		return ""
+	})
+
+	if got != "" {
+		t.Fatalf("dropped paste = %q, want empty line", got)
 	}
 }
 

--- a/shell.go
+++ b/shell.go
@@ -57,6 +57,10 @@ type Shell struct {
 	// Once enabled, set to nil to disable again.
 	SyntaxHighlighter func(line []rune) string
 
+	// PasteTransformer, when set, rewrites bracketed paste payloads before
+	// they are inserted into the input buffer.
+	PasteTransformer func(text string) string
+
 	// Completer is a function that produces completions.
 	// It takes the readline line ([]rune) and cursor pos as parameters,
 	// and returns completions with their associated metadata/settings.
@@ -114,6 +118,16 @@ func NewShell(opts ...inputrc.Option) *Shell {
 	shell.Display = display
 
 	return shell
+}
+
+// SetPasteTransformer sets a function used to rewrite bracketed paste payloads
+// before they are inserted into the input buffer. Passing nil disables it.
+func (rl *Shell) SetPasteTransformer(fn func(text string) string) {
+	if rl == nil {
+		return
+	}
+
+	rl.PasteTransformer = fn
 }
 
 // Line is the shell input line buffer.


### PR DESCRIPTION
Background

Interactive AI and command consoles often need to handle large multiline pastes differently from normal typing. A common UX is the Claude Code-style paste reference: the editable prompt shows a compact placeholder such as `[Pasted text #1 +6 lines]`, while the application keeps the original pasted payload and expands it later when executing or sending the request.

Today readline normalizes a bracketed paste and inserts it directly into the line buffer. Applications that want the placeholder/reference behavior have to duplicate paste handling or patch readline internals.

Approach

- Add `Shell.PasteTransformer` and `SetPasteTransformer`.
- Route bracketed paste insertion through a helper that preserves the existing CRLF/CR normalization.
- Let applications rewrite the pasted payload before insertion, including replacing it with a placeholder like `[Pasted text #1 +6 lines]`.
- Treat an empty transformed string as "do not insert".

The reference store and later expansion are intentionally left to the application layer. Readline only provides the safe hook at the point where terminal paste has already been read and normalized.

Tests

- Added coverage that the transformer receives normalized text.
- Added coverage that a transformer can rewrite or drop pasted text.
- Ran `go test ./...`