### PR TITLE
Add inline suggestion display API

### DIFF
--- a/inline_test.go
+++ b/inline_test.go
@@ -1,0 +1,17 @@
+package readline
+
+import "testing"
+
+func TestInlineSuggestionAPI(t *testing.T) {
+	rl := NewShell()
+
+	rl.SetInlineSuggestion("status --verbose")
+	if got := rl.GetInlineSuggestion(); got != "status --verbose" {
+		t.Fatalf("inline suggestion = %q, want status --verbose", got)
+	}
+
+	rl.ClearInlineSuggestion()
+	if got := rl.GetInlineSuggestion(); got != "" {
+		t.Fatalf("inline suggestion after clear = %q, want empty", got)
+	}
+}

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/reeflective/readline/inputrc"
 	"github.com/reeflective/readline/internal/color"
@@ -43,6 +44,7 @@ type Engine struct {
 	line      *core.Line
 	suggested core.Line
 	cursor    *core.Cursor
+	inline    string
 	selection *core.Selection
 	histories *history.Sources
 	prompt    *ui.Prompt
@@ -69,6 +71,46 @@ func NewEngine(k *core.Keys, s *core.Selection, h *history.Sources, p *ui.Prompt
 // have bound it after instantiating a new shell instance.
 func Init(e *Engine, highlighter func([]rune) string) {
 	e.highlighter = highlighter
+}
+
+// SetInlineSuggestion sets a suggestion to display after the cursor.
+func (e *Engine) SetInlineSuggestion(suggestion string) {
+	e.inline = suggestion
+}
+
+// ClearInlineSuggestion clears the current inline suggestion.
+func (e *Engine) ClearInlineSuggestion() {
+	e.inline = ""
+}
+
+// GetInlineSuggestion returns the current inline suggestion.
+func (e *Engine) GetInlineSuggestion() string {
+	return e.inline
+}
+
+func (e *Engine) inlineSuggestionApplies(currentLine string) bool {
+	if e.inline == "" {
+		return false
+	}
+	if e.cursor.Pos() != e.line.Len() {
+		return false
+	}
+
+	return strings.HasPrefix(e.inline, currentLine) && len(e.inline) > len(currentLine)
+}
+
+func (e *Engine) coordinatesLine(suggested bool) *core.Line {
+	currentLine := string(*e.line)
+	if e.opts.GetBool("history-autosuggest") && suggested && e.suggested.Len() > e.line.Len() {
+		return &e.suggested
+	}
+	if e.inlineSuggestionApplies(currentLine) {
+		inline := core.Line{}
+		inline.Set([]rune(e.inline)...)
+		return &inline
+	}
+
+	return e.line
 }
 
 // PrintPrimaryPrompt redraws the primary prompt.
@@ -202,11 +244,7 @@ func (e *Engine) computeCoordinates(suggested bool) {
 	e.cursorCol, e.cursorRow = core.CoordinatesCursor(e.cursor, e.startCols)
 
 	// Get the number of rows used by the line, and the end line X pos.
-	if e.opts.GetBool("history-autosuggest") && suggested {
-		e.lineCol, e.lineRows = core.CoordinatesLine(&e.suggested, e.startCols)
-	} else {
-		e.lineCol, e.lineRows = core.CoordinatesLine(e.line, e.startCols)
-	}
+	e.lineCol, e.lineRows = core.CoordinatesLine(e.coordinatesLine(suggested), e.startCols)
 
 	e.primaryPrinted = false
 }
@@ -231,8 +269,15 @@ func (e *Engine) displayLine() {
 	line = e.highlightLine([]rune(line), *e.selection)
 
 	// Get the subset of the suggested line to print.
+	suggestionAdded := false
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
 		line += color.Dim + color.Fmt(color.Fg+"242") + string(e.suggested[e.line.Len():]) + color.Reset
+		suggestionAdded = true
+	}
+
+	currentLine := string(*e.line)
+	if !suggestionAdded && e.inlineSuggestionApplies(currentLine) {
+		line += color.Dim + color.Fmt(color.Fg+"242") + e.inline[len(currentLine):] + color.Reset
 	}
 
 	// Format tabs as spaces, for consistent display

--- a/internal/display/inline_test.go
+++ b/internal/display/inline_test.go
@@ -1,0 +1,73 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/inputrc"
+	"github.com/reeflective/readline/internal/core"
+)
+
+func TestInlineSuggestionAppliesOnlyAtLineEndWithPrefix(t *testing.T) {
+	line := core.Line{}
+	line.Set([]rune("sta")...)
+	cursor := core.NewCursor(&line)
+	cursor.Set(line.Len())
+
+	engine := &Engine{line: &line, cursor: cursor}
+	engine.SetInlineSuggestion("status")
+
+	if !engine.inlineSuggestionApplies("sta") {
+		t.Fatal("inline suggestion should apply when it extends the line at the cursor")
+	}
+
+	cursor.Set(1)
+	if engine.inlineSuggestionApplies("sta") {
+		t.Fatal("inline suggestion should not apply when the cursor is not at the end")
+	}
+
+	cursor.Set(line.Len())
+	engine.SetInlineSuggestion("stop")
+	if engine.inlineSuggestionApplies("sta") {
+		t.Fatal("inline suggestion should not apply when it does not extend the current line")
+	}
+}
+
+func TestCoordinatesLineUsesInlineSuggestion(t *testing.T) {
+	line := core.Line{}
+	line.Set([]rune("sta")...)
+	cursor := core.NewCursor(&line)
+	cursor.Set(line.Len())
+
+	engine := &Engine{
+		line:   &line,
+		cursor: cursor,
+		opts:   inputrc.NewConfig(),
+	}
+	engine.SetInlineSuggestion("status --verbose")
+
+	if got := engine.coordinatesLine(true); string(*got) != "status --verbose" {
+		t.Fatalf("coordinates line = %q, want inline suggestion", string(*got))
+	}
+}
+
+func TestCoordinatesLinePrefersHistorySuggestion(t *testing.T) {
+	line := core.Line{}
+	line.Set([]rune("sta")...)
+	cursor := core.NewCursor(&line)
+	cursor.Set(line.Len())
+
+	cfg := inputrc.NewConfig()
+	_ = cfg.Set("history-autosuggest", true)
+
+	engine := &Engine{
+		line:   &line,
+		cursor: cursor,
+		opts:   cfg,
+	}
+	engine.suggested.Set([]rune("status-from-history")...)
+	engine.SetInlineSuggestion("status-from-inline")
+
+	if got := engine.coordinatesLine(true); string(*got) != "status-from-history" {
+		t.Fatalf("coordinates line = %q, want history suggestion", string(*got))
+	}
+}

--- a/internal/display/refresh.go
+++ b/internal/display/refresh.go
@@ -41,7 +41,7 @@ func (e *Engine) Refresh() {
 	// Recompute coordinates with the new indentation/cursor position.
 	if e.line.Lines() > 0 {
 		e.cursorCol, e.cursorRow = core.CoordinatesCursor(e.cursor, e.startCols)
-		e.lineCol, e.lineRows = core.CoordinatesLine(e.line, e.startCols)
+		e.lineCol, e.lineRows = core.CoordinatesLine(e.coordinatesLine(true), e.startCols)
 	}
 
 	// Ensure that we have enough space to print the line.
@@ -268,8 +268,15 @@ func (e *Engine) displayLineRefactored() {
 	// Apply visual selections highlighting if any
 	line = e.highlightLine([]rune(line), *e.selection)
 	// Get the subset of the suggested line to print.
+	suggestionAdded := false
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
 		line += color.Dim + color.Fmt(color.Fg+"242") + string(e.suggested[e.line.Len():]) + color.Reset
+		suggestionAdded = true
+	}
+
+	currentLine := string(*e.line)
+	if !suggestionAdded && e.inlineSuggestionApplies(currentLine) {
+		line += color.Dim + color.Fmt(color.Fg+"242") + e.inline[len(currentLine):] + color.Reset
 	}
 	// Format tabs as spaces, for consistent display
 	line = strutil.FormatTabs(line) + term.ClearLineAfter

--- a/shell.go
+++ b/shell.go
@@ -176,3 +176,30 @@ func (rl *Shell) PrintTransientf(msg string, args ...any) (n int, err error) {
 
 	return
 }
+
+// SetInlineSuggestion sets a suggestion to display after the cursor.
+func (rl *Shell) SetInlineSuggestion(suggestion string) {
+	if rl == nil || rl.Display == nil {
+		return
+	}
+
+	rl.Display.SetInlineSuggestion(suggestion)
+}
+
+// ClearInlineSuggestion clears the current inline suggestion.
+func (rl *Shell) ClearInlineSuggestion() {
+	if rl == nil || rl.Display == nil {
+		return
+	}
+
+	rl.Display.ClearInlineSuggestion()
+}
+
+// GetInlineSuggestion returns the current inline suggestion.
+func (rl *Shell) GetInlineSuggestion() string {
+	if rl == nil || rl.Display == nil {
+		return ""
+	}
+
+	return rl.Display.GetInlineSuggestion()
+}


### PR DESCRIPTION
Background

Applications that build interactive shells often have suggestions that do not come from readline history: AI command suggestions, remote completions, or application-specific prediction engines. These suggestions are best displayed as ghost text after the cursor, similar to history autosuggest, but callers currently have no public API to provide such text.

Approach

- Add `Shell.SetInlineSuggestion`, `Shell.ClearInlineSuggestion`, and `Shell.GetInlineSuggestion`.
- Store the suggestion in the display engine and render only the suffix after the current line.
- Apply the suggestion only when the cursor is at the end of the line and the suggestion extends the current line.
- Keep existing history autosuggest behavior first, so history suggestions continue to win when enabled and available.
- Include the inline suggestion in display coordinate calculation so wrapping and cleanup account for the ghost text width.

Tests

- Added public API coverage for set/get/clear.
- Added display-engine tests for prefix matching, cursor-position gating, coordinate line selection, and history-autosuggest precedence.
- Ran `go test ./...`