### PR TITLE
Merge open contributions: history fix, paste transformer, inline suggestions

### DIFF
--- a/emacs.go
+++ b/emacs.go
@@ -476,14 +476,25 @@ func (rl *Shell) bracketedPasteBegin() {
 	}
 
 	if len(sequence) > 6 {
-		pasted := string(sequence[:len(sequence)-6])
-		// Terminals send \r (or \r\n) for line breaks inside a bracketed paste.
-		// Normalise them to \n, otherwise the stray carriage returns corrupt the
-		// line buffer and break multiline display and evaluation.
-		pasted = strings.ReplaceAll(pasted, "\r\n", "\n")
-		pasted = strings.ReplaceAll(pasted, "\r", "\n")
-		rl.cursor.InsertAt([]rune(pasted)...)
+		rl.insertPastedText(string(sequence[:len(sequence)-6]))
 	}
+}
+
+func (rl *Shell) insertPastedText(text string) {
+	// Terminals send \r (or \r\n) for line breaks inside a bracketed paste.
+	// Normalise them to \n, otherwise the stray carriage returns corrupt the
+	// line buffer and break multiline display and evaluation.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+
+	if rl.PasteTransformer != nil {
+		text = rl.PasteTransformer(text)
+	}
+	if text == "" {
+		return
+	}
+
+	rl.cursor.InsertAt([]rune(text)...)
 }
 
 // skipCsiSequence consumes the remainder of a CSI escape sequence (the GNU

--- a/emacs.go
+++ b/emacs.go
@@ -170,6 +170,12 @@ func (rl *Shell) forwardChar() {
 		rl.autosuggestAccept()
 	}
 
+	// Fall back to an application-provided inline suggestion when history
+	// autosuggest accepted nothing and the cursor is at the end of the line.
+	if rl.cursor.Pos() == startPos {
+		rl.acceptInlineSuggestion()
+	}
+
 	if rl.cursor.Pos() > startPos {
 		return
 	}

--- a/emacs_test.go
+++ b/emacs_test.go
@@ -12,12 +12,19 @@ import (
 func feedPaste(t *testing.T, payload string) string {
 	t.Helper()
 
+	return feedPasteWithTransformer(t, payload, nil)
+}
+
+func feedPasteWithTransformer(t *testing.T, payload string, transformer func(string) string) string {
+	t.Helper()
+
 	line := new(core.Line)
 	rl := &Shell{
 		Keys:   new(core.Keys),
 		line:   line,
 		cursor: core.NewCursor(line),
 	}
+	rl.PasteTransformer = transformer
 
 	// The handler consumes keys until it sees the paste-end sequence, so the
 	// terminator must be fed too — otherwise it would block waiting for input.
@@ -49,6 +56,30 @@ func TestBracketedPasteNormalizesCarriageReturns(t *testing.T) {
 				t.Fatalf("paste %q => %q, want %q", c.payload, got, c.want)
 			}
 		})
+	}
+}
+
+func TestBracketedPasteTransformer(t *testing.T) {
+	got := feedPasteWithTransformer(t, "a\r\nb", func(text string) string {
+		if text != "a\nb" {
+			t.Fatalf("transformer saw %q, want normalized text", text)
+		}
+
+		return "rewritten"
+	})
+
+	if got != "rewritten" {
+		t.Fatalf("transformed paste = %q, want rewritten", got)
+	}
+}
+
+func TestBracketedPasteTransformerCanDropText(t *testing.T) {
+	got := feedPasteWithTransformer(t, "secret", func(string) string {
+		return ""
+	})
+
+	if got != "" {
+		t.Fatalf("dropped paste = %q, want empty line", got)
 	}
 }
 

--- a/history.go
+++ b/history.go
@@ -77,6 +77,12 @@ func (rl *Shell) historyCommands() commands {
 		"autosuggest-enable":                 rl.autosuggestEnable,
 		"autosuggest-disable":                rl.autosuggestDisable,
 		"autosuggest-toggle":                 rl.autosuggestToggle,
+
+		// Application-provided inline suggestions (see Shell.SetInlineSuggestion).
+		// These are not tied to history, but are grouped here as they are the
+		// sibling ghost-text acceptance commands.
+		"inline-suggest-accept":      rl.inlineSuggestAccept,
+		"inline-suggest-accept-word": rl.inlineSuggestAcceptWord,
 	}
 
 	return widgets

--- a/inline_accept_test.go
+++ b/inline_accept_test.go
@@ -1,0 +1,72 @@
+package readline
+
+import "testing"
+
+// setLine replaces the shell's line buffer and puts the cursor at its end.
+func setLine(rl *Shell, s string) {
+	rl.line.Set([]rune(s)...)
+	rl.cursor.Set(rl.line.Len())
+}
+
+func TestInlineSuggestAcceptFull(t *testing.T) {
+	rl := NewShell()
+	setLine(rl, "sta")
+	rl.SetInlineSuggestion("status --verbose")
+
+	rl.inlineSuggestAccept()
+
+	if got := string(*rl.line); got != "status --verbose" {
+		t.Fatalf("line after accept = %q, want %q", got, "status --verbose")
+	}
+	if got := rl.GetInlineSuggestion(); got != "" {
+		t.Fatalf("inline suggestion after accept = %q, want cleared", got)
+	}
+}
+
+func TestInlineSuggestAcceptWord(t *testing.T) {
+	rl := NewShell()
+	setLine(rl, "sta")
+	rl.SetInlineSuggestion("status --verbose")
+
+	rl.inlineSuggestAcceptWord()
+
+	if got := string(*rl.line); got != "status" {
+		t.Fatalf("line after word accept = %q, want %q", got, "status")
+	}
+	// Suggestion still extends the line, so it must not be cleared.
+	if got := rl.GetInlineSuggestion(); got != "status --verbose" {
+		t.Fatalf("inline suggestion after word accept = %q, want unchanged", got)
+	}
+
+	// A second word-accept consumes the remainder and clears the suggestion.
+	rl.inlineSuggestAcceptWord()
+	if got := string(*rl.line); got != "status --verbose" {
+		t.Fatalf("line after second word accept = %q, want %q", got, "status --verbose")
+	}
+	if got := rl.GetInlineSuggestion(); got != "" {
+		t.Fatalf("inline suggestion after full consumption = %q, want cleared", got)
+	}
+}
+
+func TestInlineSuggestAcceptNotApplicable(t *testing.T) {
+	rl := NewShell()
+	setLine(rl, "xyz") // suggestion does not extend the current line
+	rl.SetInlineSuggestion("status")
+
+	rl.inlineSuggestAccept()
+
+	if got := string(*rl.line); got != "xyz" {
+		t.Fatalf("line = %q, want unchanged %q", got, "xyz")
+	}
+
+	// Cursor not at end of line: must not accept.
+	setLine(rl, "sta")
+	rl.cursor.Set(1)
+	rl.SetInlineSuggestion("status")
+
+	rl.inlineSuggestAccept()
+
+	if got := string(*rl.line); got != "sta" {
+		t.Fatalf("line = %q, want unchanged %q (cursor not at end)", got, "sta")
+	}
+}

--- a/inline_test.go
+++ b/inline_test.go
@@ -1,0 +1,17 @@
+package readline
+
+import "testing"
+
+func TestInlineSuggestionAPI(t *testing.T) {
+	rl := NewShell()
+
+	rl.SetInlineSuggestion("status --verbose")
+	if got := rl.GetInlineSuggestion(); got != "status --verbose" {
+		t.Fatalf("inline suggestion = %q, want status --verbose", got)
+	}
+
+	rl.ClearInlineSuggestion()
+	if got := rl.GetInlineSuggestion(); got != "" {
+		t.Fatalf("inline suggestion after clear = %q, want empty", got)
+	}
+}

--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/reeflective/readline/inputrc"
 	"github.com/reeflective/readline/internal/color"
@@ -43,6 +44,7 @@ type Engine struct {
 	line      *core.Line
 	suggested core.Line
 	cursor    *core.Cursor
+	inline    string
 	selection *core.Selection
 	histories *history.Sources
 	prompt    *ui.Prompt
@@ -69,6 +71,46 @@ func NewEngine(k *core.Keys, s *core.Selection, h *history.Sources, p *ui.Prompt
 // have bound it after instantiating a new shell instance.
 func Init(e *Engine, highlighter func([]rune) string) {
 	e.highlighter = highlighter
+}
+
+// SetInlineSuggestion sets a suggestion to display after the cursor.
+func (e *Engine) SetInlineSuggestion(suggestion string) {
+	e.inline = suggestion
+}
+
+// ClearInlineSuggestion clears the current inline suggestion.
+func (e *Engine) ClearInlineSuggestion() {
+	e.inline = ""
+}
+
+// GetInlineSuggestion returns the current inline suggestion.
+func (e *Engine) GetInlineSuggestion() string {
+	return e.inline
+}
+
+func (e *Engine) inlineSuggestionApplies(currentLine string) bool {
+	if e.inline == "" {
+		return false
+	}
+	if e.cursor.Pos() != e.line.Len() {
+		return false
+	}
+
+	return strings.HasPrefix(e.inline, currentLine) && len(e.inline) > len(currentLine)
+}
+
+func (e *Engine) coordinatesLine(suggested bool) *core.Line {
+	currentLine := string(*e.line)
+	if e.opts.GetBool("history-autosuggest") && suggested && e.suggested.Len() > e.line.Len() {
+		return &e.suggested
+	}
+	if e.inlineSuggestionApplies(currentLine) {
+		inline := core.Line{}
+		inline.Set([]rune(e.inline)...)
+		return &inline
+	}
+
+	return e.line
 }
 
 // PrintPrimaryPrompt redraws the primary prompt.
@@ -202,11 +244,7 @@ func (e *Engine) computeCoordinates(suggested bool) {
 	e.cursorCol, e.cursorRow = core.CoordinatesCursor(e.cursor, e.startCols)
 
 	// Get the number of rows used by the line, and the end line X pos.
-	if e.opts.GetBool("history-autosuggest") && suggested {
-		e.lineCol, e.lineRows = core.CoordinatesLine(&e.suggested, e.startCols)
-	} else {
-		e.lineCol, e.lineRows = core.CoordinatesLine(e.line, e.startCols)
-	}
+	e.lineCol, e.lineRows = core.CoordinatesLine(e.coordinatesLine(suggested), e.startCols)
 
 	e.primaryPrinted = false
 }
@@ -231,8 +269,15 @@ func (e *Engine) displayLine() {
 	line = e.highlightLine([]rune(line), *e.selection)
 
 	// Get the subset of the suggested line to print.
+	suggestionAdded := false
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
 		line += color.Dim + color.Fmt(color.Fg+"242") + string(e.suggested[e.line.Len():]) + color.Reset
+		suggestionAdded = true
+	}
+
+	currentLine := string(*e.line)
+	if !suggestionAdded && e.inlineSuggestionApplies(currentLine) {
+		line += color.Dim + color.Fmt(color.Fg+"242") + e.inline[len(currentLine):] + color.Reset
 	}
 
 	// Format tabs as spaces, for consistent display

--- a/internal/display/inline.go
+++ b/internal/display/inline.go
@@ -1,0 +1,63 @@
+package display
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/reeflective/readline/internal/core"
+)
+
+// AcceptInline replaces the line buffer with the inline suggestion when one
+// applies at the cursor, clears the suggestion, and reports whether it did so.
+// Callers pass the line/cursor to accept onto, since the engine's own line may
+// point at a minibuffer during completion or search.
+func (e *Engine) AcceptInline(line *core.Line, cursor *core.Cursor) bool {
+	if !e.inlineAcceptable(line, cursor) {
+		return false
+	}
+
+	line.Set([]rune(e.inline)...)
+	cursor.Set(line.Len())
+	e.inline = ""
+
+	return true
+}
+
+// AcceptInlineWord accepts the next word of the inline suggestion, leaving the
+// rest as a suggestion. It follows forward-word semantics: any leading
+// whitespace plus the following run of non-whitespace runes are inserted.
+func (e *Engine) AcceptInlineWord(line *core.Line, cursor *core.Cursor) {
+	if !e.inlineAcceptable(line, cursor) {
+		return
+	}
+
+	sug := []rune(e.inline)
+	from := line.Len()
+	remainder := sug[from:]
+
+	pos := 0
+	for pos < len(remainder) && unicode.IsSpace(remainder[pos]) {
+		pos++
+	}
+
+	for pos < len(remainder) && !unicode.IsSpace(remainder[pos]) {
+		pos++
+	}
+
+	line.Set(sug[:from+pos]...)
+	cursor.Set(line.Len())
+
+	if from+pos >= len(sug) {
+		e.inline = ""
+	}
+}
+
+// inlineAcceptable reports whether the inline suggestion can be accepted onto
+// the given line: the cursor must be at the end of the line and the suggestion
+// must extend it (mirrors the display gate in inlineSuggestionApplies).
+func (e *Engine) inlineAcceptable(line *core.Line, cursor *core.Cursor) bool {
+	return e.inline != "" &&
+		cursor.Pos() == line.Len() &&
+		strings.HasPrefix(e.inline, string(*line)) &&
+		len([]rune(e.inline)) > line.Len()
+}

--- a/internal/display/inline_accept_test.go
+++ b/internal/display/inline_accept_test.go
@@ -1,0 +1,70 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/internal/core"
+)
+
+func newInlineEngine(t *testing.T, buf, suggestion string) (*Engine, *core.Line, *core.Cursor) {
+	t.Helper()
+
+	line := &core.Line{}
+	line.Set([]rune(buf)...)
+	cursor := core.NewCursor(line)
+	cursor.Set(line.Len())
+
+	engine := &Engine{}
+	engine.SetInlineSuggestion(suggestion)
+
+	return engine, line, cursor
+}
+
+func TestAcceptInlineFull(t *testing.T) {
+	engine, line, cursor := newInlineEngine(t, "sta", "status --verbose")
+
+	if !engine.AcceptInline(line, cursor) {
+		t.Fatal("AcceptInline returned false, want the suggestion accepted")
+	}
+	if got := string(*line); got != "status --verbose" {
+		t.Fatalf("line = %q, want %q", got, "status --verbose")
+	}
+	if engine.GetInlineSuggestion() != "" {
+		t.Fatal("inline suggestion not cleared after full accept")
+	}
+}
+
+func TestAcceptInlineWordThenRemainder(t *testing.T) {
+	engine, line, cursor := newInlineEngine(t, "sta", "status --verbose")
+
+	engine.AcceptInlineWord(line, cursor)
+	if got := string(*line); got != "status" {
+		t.Fatalf("line after word accept = %q, want %q", got, "status")
+	}
+	if engine.GetInlineSuggestion() != "status --verbose" {
+		t.Fatal("suggestion cleared too early: it still extends the line")
+	}
+
+	engine.AcceptInlineWord(line, cursor)
+	if got := string(*line); got != "status --verbose" {
+		t.Fatalf("line after second word accept = %q, want %q", got, "status --verbose")
+	}
+	if engine.GetInlineSuggestion() != "" {
+		t.Fatal("inline suggestion not cleared after remainder consumed")
+	}
+}
+
+func TestAcceptInlineGated(t *testing.T) {
+	// Cursor not at line end.
+	engine, line, cursor := newInlineEngine(t, "sta", "status")
+	cursor.Set(1)
+	if engine.AcceptInline(line, cursor) {
+		t.Fatal("AcceptInline accepted with cursor away from line end")
+	}
+
+	// Suggestion does not extend the current line.
+	engine2, line2, cursor2 := newInlineEngine(t, "xyz", "status")
+	if engine2.AcceptInline(line2, cursor2) {
+		t.Fatal("AcceptInline accepted a non-extending suggestion")
+	}
+}

--- a/internal/display/inline_test.go
+++ b/internal/display/inline_test.go
@@ -1,0 +1,73 @@
+package display
+
+import (
+	"testing"
+
+	"github.com/reeflective/readline/inputrc"
+	"github.com/reeflective/readline/internal/core"
+)
+
+func TestInlineSuggestionAppliesOnlyAtLineEndWithPrefix(t *testing.T) {
+	line := core.Line{}
+	line.Set([]rune("sta")...)
+	cursor := core.NewCursor(&line)
+	cursor.Set(line.Len())
+
+	engine := &Engine{line: &line, cursor: cursor}
+	engine.SetInlineSuggestion("status")
+
+	if !engine.inlineSuggestionApplies("sta") {
+		t.Fatal("inline suggestion should apply when it extends the line at the cursor")
+	}
+
+	cursor.Set(1)
+	if engine.inlineSuggestionApplies("sta") {
+		t.Fatal("inline suggestion should not apply when the cursor is not at the end")
+	}
+
+	cursor.Set(line.Len())
+	engine.SetInlineSuggestion("stop")
+	if engine.inlineSuggestionApplies("sta") {
+		t.Fatal("inline suggestion should not apply when it does not extend the current line")
+	}
+}
+
+func TestCoordinatesLineUsesInlineSuggestion(t *testing.T) {
+	line := core.Line{}
+	line.Set([]rune("sta")...)
+	cursor := core.NewCursor(&line)
+	cursor.Set(line.Len())
+
+	engine := &Engine{
+		line:   &line,
+		cursor: cursor,
+		opts:   inputrc.NewConfig(),
+	}
+	engine.SetInlineSuggestion("status --verbose")
+
+	if got := engine.coordinatesLine(true); string(*got) != "status --verbose" {
+		t.Fatalf("coordinates line = %q, want inline suggestion", string(*got))
+	}
+}
+
+func TestCoordinatesLinePrefersHistorySuggestion(t *testing.T) {
+	line := core.Line{}
+	line.Set([]rune("sta")...)
+	cursor := core.NewCursor(&line)
+	cursor.Set(line.Len())
+
+	cfg := inputrc.NewConfig()
+	_ = cfg.Set("history-autosuggest", true)
+
+	engine := &Engine{
+		line:   &line,
+		cursor: cursor,
+		opts:   cfg,
+	}
+	engine.suggested.Set([]rune("status-from-history")...)
+	engine.SetInlineSuggestion("status-from-inline")
+
+	if got := engine.coordinatesLine(true); string(*got) != "status-from-history" {
+		t.Fatalf("coordinates line = %q, want history suggestion", string(*got))
+	}
+}

--- a/internal/display/refresh.go
+++ b/internal/display/refresh.go
@@ -41,7 +41,7 @@ func (e *Engine) Refresh() {
 	// Recompute coordinates with the new indentation/cursor position.
 	if e.line.Lines() > 0 {
 		e.cursorCol, e.cursorRow = core.CoordinatesCursor(e.cursor, e.startCols)
-		e.lineCol, e.lineRows = core.CoordinatesLine(e.line, e.startCols)
+		e.lineCol, e.lineRows = core.CoordinatesLine(e.coordinatesLine(true), e.startCols)
 	}
 
 	// Ensure that we have enough space to print the line.
@@ -268,8 +268,15 @@ func (e *Engine) displayLineRefactored() {
 	// Apply visual selections highlighting if any
 	line = e.highlightLine([]rune(line), *e.selection)
 	// Get the subset of the suggested line to print.
+	suggestionAdded := false
 	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
 		line += color.Dim + color.Fmt(color.Fg+"242") + string(e.suggested[e.line.Len():]) + color.Reset
+		suggestionAdded = true
+	}
+
+	currentLine := string(*e.line)
+	if !suggestionAdded && e.inlineSuggestionApplies(currentLine) {
+		line += color.Dim + color.Fmt(color.Fg+"242") + e.inline[len(currentLine):] + color.Reset
 	}
 	// Format tabs as spaces, for consistent display
 	line = strutil.FormatTabs(line) + term.ClearLineAfter

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -45,8 +45,12 @@ func (h *memory) Write(s string) (int, error) {
 
 // GetLine returns a line from history.
 func (h *memory) GetLine(i int) (string, error) {
-	if len(h.items) == 0 {
-		return "", nil
+	if i < 0 {
+		return "", errNegativeIndex
+	}
+
+	if i >= len(h.items) {
+		return "", errOutOfRangeIndex
 	}
 
 	return h.items[i], nil

--- a/internal/history/sources_test.go
+++ b/internal/history/sources_test.go
@@ -83,3 +83,20 @@ func TestWriteZeroMaxIsUnlimited(t *testing.T) {
 		t.Fatalf("maxEntries==0 wrote %d lines, want 2 (should be unlimited)", mem.Len())
 	}
 }
+
+// TestMemoryGetLineOutOfRange guards memory.GetLine against an index past the
+// end of the buffer: it must return an error like the file source does, not
+// panic with "index out of range". History navigation (e.g. down-arrow at the
+// newest entry) can ask for position Len().
+func TestMemoryGetLineOutOfRange(t *testing.T) {
+	mem := new(memory)
+	mem.Write("test")
+
+	if _, err := mem.GetLine(mem.Len()); err == nil {
+		t.Fatalf("GetLine(%d) on a %d-line history returned nil error, want out-of-range error", mem.Len(), mem.Len())
+	}
+
+	if _, err := mem.GetLine(-1); err == nil {
+		t.Fatalf("GetLine(-1) returned nil error, want negative-index error")
+	}
+}

--- a/shell.go
+++ b/shell.go
@@ -207,3 +207,30 @@ func (rl *Shell) GetInlineSuggestion() string {
 
 	return rl.Display.GetInlineSuggestion()
 }
+
+// inlineSuggestAccept (inline-suggest-accept) accepts the entire
+// application-provided inline suggestion into the line buffer.
+func (rl *Shell) inlineSuggestAccept() {
+	rl.acceptInlineSuggestion()
+}
+
+// inlineSuggestAcceptWord (inline-suggest-accept-word) accepts the next word of
+// the inline suggestion, leaving the rest as a suggestion.
+func (rl *Shell) inlineSuggestAcceptWord() {
+	if rl == nil || rl.Display == nil {
+		return
+	}
+
+	rl.Display.AcceptInlineWord(rl.line, rl.cursor)
+}
+
+// acceptInlineSuggestion accepts the inline suggestion if one applies at the
+// cursor, returning whether it did. Movement commands use it to fall back to an
+// application-provided suggestion once history autosuggest has been considered.
+func (rl *Shell) acceptInlineSuggestion() bool {
+	if rl == nil || rl.Display == nil {
+		return false
+	}
+
+	return rl.Display.AcceptInline(rl.line, rl.cursor)
+}

--- a/shell.go
+++ b/shell.go
@@ -57,6 +57,10 @@ type Shell struct {
 	// Once enabled, set to nil to disable again.
 	SyntaxHighlighter func(line []rune) string
 
+	// PasteTransformer, when set, rewrites bracketed paste payloads before
+	// they are inserted into the input buffer.
+	PasteTransformer func(text string) string
+
 	// Completer is a function that produces completions.
 	// It takes the readline line ([]rune) and cursor pos as parameters,
 	// and returns completions with their associated metadata/settings.

--- a/shell.go
+++ b/shell.go
@@ -176,3 +176,30 @@ func (rl *Shell) PrintTransientf(msg string, args ...any) (n int, err error) {
 
 	return
 }
+
+// SetInlineSuggestion sets a suggestion to display after the cursor.
+func (rl *Shell) SetInlineSuggestion(suggestion string) {
+	if rl == nil || rl.Display == nil {
+		return
+	}
+
+	rl.Display.SetInlineSuggestion(suggestion)
+}
+
+// ClearInlineSuggestion clears the current inline suggestion.
+func (rl *Shell) ClearInlineSuggestion() {
+	if rl == nil || rl.Display == nil {
+		return
+	}
+
+	rl.Display.ClearInlineSuggestion()
+}
+
+// GetInlineSuggestion returns the current inline suggestion.
+func (rl *Shell) GetInlineSuggestion() string {
+	if rl == nil || rl.Display == nil {
+		return ""
+	}
+
+	return rl.Display.GetInlineSuggestion()
+}

--- a/vim.go
+++ b/vim.go
@@ -244,6 +244,12 @@ func (rl *Shell) viForwardChar() {
 		return
 	}
 
+	// Application-provided inline suggestion (accepted when the cursor is at
+	// the end of the line, e.g. in vi-insert mode).
+	if rl.acceptInlineSuggestion() {
+		return
+	}
+
 	rl.History.SkipSave()
 
 	// In vi-cmd-mode, we don't go further than the


### PR DESCRIPTION
Bundles the reviewed open contributions onto `dev`, recommitted as signed commits with original authorship preserved.

## Included

- **fix(history): return an error from `memory.GetLine` on out-of-range index** (#111, @SAY-5, fixes #110)
  The in-memory history source now returns `errNegativeIndex`/`errOutOfRangeIndex` instead of panicking, matching the file-backed source's contract. All `GetLine` callers already treat the error as recoverable.

- **Add a bracketed paste transformer hook** (#113, @M09Ic)
  New exported `Shell.PasteTransformer` field, letting applications rewrite a normalized paste payload before insertion (e.g. replace it with a `[Pasted text #1 +6 lines]` placeholder). Empty result inserts nothing. *Merged with the `SetPasteTransformer` method dropped — the bare field matches the `SyntaxHighlighter`/`Completer` convention.*

- **Add inline suggestion display API** (#114, @M09Ic)
  `Shell.SetInlineSuggestion`/`ClearInlineSuggestion`/`GetInlineSuggestion` render application-provided ghost text after the cursor (AI predictions, remote completions, …), gated to line-end with a prefix match. History autosuggest keeps priority.

- **feat(inline): commands to accept inline suggestions** (new)
  Adds the missing input side for the display API:
  - `inline-suggest-accept` — accept the whole suggestion.
  - `inline-suggest-accept-word` — accept the next word.
  - `forward-char` / `vi-forward-char` fall back to accepting an inline suggestion at line-end when history autosuggest accepted nothing.
  Acceptance logic lives in `internal/display`; thin `*Shell` command wrappers in the root package.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- New unit tests in `internal/display` and end-to-end tests in the root package.

Wiki updated separately: command reference plus new **Inline Suggestions** and **Bracketed Paste** pages.

Closes #110. Supersedes #111, #113, #114.