### PR TITLE
fix(display): unify line renderer and restore right-edge wrap handling

### DIFF
--- a/internal/display/engine.go
+++ b/internal/display/engine.go
@@ -5,11 +5,9 @@ import (
 	"strings"
 
 	"github.com/reeflective/readline/inputrc"
-	"github.com/reeflective/readline/internal/color"
 	"github.com/reeflective/readline/internal/completion"
 	"github.com/reeflective/readline/internal/core"
 	"github.com/reeflective/readline/internal/history"
-	"github.com/reeflective/readline/internal/strutil"
 	"github.com/reeflective/readline/internal/term"
 	"github.com/reeflective/readline/internal/ui"
 )
@@ -247,51 +245,6 @@ func (e *Engine) computeCoordinates(suggested bool) {
 	e.lineCol, e.lineRows = core.CoordinatesLine(e.coordinatesLine(suggested), e.startCols)
 
 	e.primaryPrinted = false
-}
-
-func (e *Engine) displayLine() {
-	var line string
-
-	// Apply user-defined highlighter to the input line.
-	if e.highlighter != nil {
-		line = e.highlighter(*e.line)
-	} else {
-		line = string(*e.line)
-	}
-
-	// Highlight matching parenthesis
-	if e.opts.GetBool("blink-matching-paren") {
-		core.HighlightMatchers(e.selection)
-		defer core.ResetMatchers(e.selection)
-	}
-
-	// Apply visual selections highlighting if any
-	line = e.highlightLine([]rune(line), *e.selection)
-
-	// Get the subset of the suggested line to print.
-	suggestionAdded := false
-	if len(e.suggested) > e.line.Len() && e.opts.GetBool("history-autosuggest") {
-		line += color.Dim + color.Fmt(color.Fg+"242") + string(e.suggested[e.line.Len():]) + color.Reset
-		suggestionAdded = true
-	}
-
-	currentLine := string(*e.line)
-	if !suggestionAdded && e.inlineSuggestionApplies(currentLine) {
-		line += color.Dim + color.Fmt(color.Fg+"242") + e.inline[len(currentLine):] + color.Reset
-	}
-
-	// Format tabs as spaces, for consistent display
-	line = strutil.FormatTabs(line) + term.ClearLineAfter
-
-	// And display the line.
-	e.suggested.Set([]rune(line)...)
-	core.DisplayLine(&e.suggested, e.startCols)
-
-	// Adjust the cursor if the line fits exactly in the terminal width.
-	if e.lineCol == 0 {
-		term.WriteString(term.NewlineReturn)
-		term.WriteString(term.ClearLineAfter)
-	}
 }
 
 // AvailableHelperLines returns the number of lines available below the hint section.

--- a/internal/display/hint_test.go
+++ b/internal/display/hint_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 )
 
+// compactScreen collapses all runs of whitespace so screen contents can be
+// matched irrespective of terminal padding or soft-wrap column boundaries.
+func compactScreen(screen string) string {
+	return strings.Join(strings.Fields(screen), "")
+}
+
 // rowIndex returns the index of the first screen row containing substr, or -1.
 func rowIndex(screen, substr string) int {
 	for i, row := range strings.Split(screen, "\n") {

--- a/internal/display/refresh.go
+++ b/internal/display/refresh.go
@@ -114,7 +114,7 @@ func (e *Engine) repaintPromptUpperLines() {
 }
 
 func (e *Engine) renderInputArea() {
-	e.displayLineRefactored()
+	e.displayLine()
 	e.renderMultilineIndicators()
 	e.renderRightPrompt()
 }
@@ -252,7 +252,11 @@ func (e *Engine) ensureInputSpace() {
 	term.MoveCursorForwards(e.startCols)
 }
 
-func (e *Engine) displayLineRefactored() {
+// displayLine renders the input line — highlighting, history-autosuggest and
+// inline-suggestion suffixes, and tab expansion — at the current cursor row. It
+// is the single line renderer shared by the main refresh path (renderInputArea)
+// and the transient-prompt redraw (RefreshTransient).
+func (e *Engine) displayLine() {
 	var line string
 	// Apply user-defined highlighter to the input line.
 	if e.highlighter != nil {
@@ -278,11 +282,26 @@ func (e *Engine) displayLineRefactored() {
 	if !suggestionAdded && e.inlineSuggestionApplies(currentLine) {
 		line += color.Dim + color.Fmt(color.Fg+"242") + e.inline[len(currentLine):] + color.Reset
 	}
-	// Format tabs as spaces, for consistent display
-	line = strutil.FormatTabs(line) + term.ClearLineAfter
+
+	// Format tabs as spaces, for consistent display. When the rendered input
+	// lands exactly on the terminal's right edge (lineCol == 0), the cursor is
+	// left in the terminal's pending-wrap state; emitting clear-to-end-of-line
+	// there can erase the edge glyph, so skip it in that case.
+	wrappedAtRightEdge := e.lineCol == 0 && len(line) > 0
+	line = strutil.FormatTabs(line)
+	if !wrappedAtRightEdge {
+		line += term.ClearLineAfter
+	}
+
 	// And display the line.
 	e.suggested.Set([]rune(line)...)
 	core.DisplayLine(&e.suggested, e.startCols)
+
+	// Force the pending wrap before any later clear/cursor-movement sequences,
+	// so redraws do not overwrite the edge character or scroll one row per key.
+	if wrappedAtRightEdge {
+		term.WriteString(term.NewlineReturn)
+	}
 }
 
 func (e *Engine) renderMultilineIndicators() {

--- a/internal/display/render_test.go
+++ b/internal/display/render_test.go
@@ -192,3 +192,56 @@ func TestRenderWithCursorProbeDisabled(t *testing.T) {
 		t.Fatalf("row 0 misaligned with probing disabled:\n  got:  %q\n  want: %q", row0, want)
 	}
 }
+
+// TestRenderRightEdgeWrapAtBottomKeepsInputVisiblePerKey guards the common
+// shell position: the prompt is already at the bottom of the terminal, and the
+// typed input soft-wraps at the right edge. Each keypress should keep the
+// current input visible instead of erasing the edge character or scrolling one
+// row per refresh.
+//
+// This is a regression test for the right-edge redraw fix (originally proposed
+// in PR #112 by @rztaylor): the display refactor dropped the pending-wrap
+// handling from the main render path, so typing past the right edge on the last
+// row wedged the redraw.
+func TestRenderRightEdgeWrapAtBottomKeepsInputVisiblePerKey(t *testing.T) {
+	const (
+		cols = 20
+		rows = 8
+	)
+	const prompt = "P> "
+
+	c := startConsole(t, consoleConfig{
+		prompt:  prompt,
+		cols:    cols,
+		rows:    rows,
+		prefill: rows - 1,
+	})
+
+	typed := "abcdefghijklmnopqrstu"
+	firstWrappedInputLen := cols - len(prompt) + 1
+	stableTopRow := -1
+
+	c.waitForScreen(prompt)
+	for idx, ch := range typed {
+		c.send(string(ch))
+		want := typed[:idx+1]
+
+		screen := c.waitUntil(func(screen string) bool {
+			return strings.Contains(compactScreen(screen), "P>"+want)
+		})
+
+		if idx+1 == firstWrappedInputLen {
+			stableTopRow = rowIndex(screen, prompt)
+		}
+		if idx+1 > firstWrappedInputLen {
+			if got := rowIndex(screen, prompt); got != stableTopRow {
+				t.Fatalf("prompt scrolled while typing within the same wrapped row after key %d (%q): prompt row %d, want %d\n%s", idx+1, ch, got, stableTopRow, screen)
+			}
+		}
+	}
+
+	c.send("\r")
+	c.waitUntil(func(screen string) bool {
+		return strings.Contains(compactScreen(screen), "[LINE:"+typed+"]")
+	})
+}


### PR DESCRIPTION
## Problem

Two issues, one root cause.

**1. Right-edge redraw regression (still present on `master`).** When editable input lands exactly on the terminal's right edge while the prompt is on the bottom row, terminals leave the cursor in a *pending-wrap* state. The main render path still emitted clear-to-end-of-line there, erasing the edge glyph and wedging the redraw — typing past the edge scrolled a row per keypress or stalled. This is the bug [PR #112 by @rztaylor](https://github.com/reeflective/readline/pull/112) fixed; that PR was closed without explanation and never merged. I confirmed the bug reproduces on current `master` (the PR's regression test times out) and that the fix resolves it.

**2. Duplicated render functions.** The display refactor (`b735972`) copied `displayLine` into `displayLineRefactored` for the main render path but **dropped** the original's right-edge (`lineCol == 0`) handling — that dropped block *is* the regression above. The two functions then lived on as near-identical copies:
- `displayLineRefactored` (refresh.go) → main per-keystroke path
- `displayLine` (engine.go) → only `RefreshTransient`

They had already drifted: the inline-suggestion work (#114) had to patch **both**, and #112 patched only one. A latent trap.

## Fix

Collapse them into a **single `displayLine`**, shared by both the main refresh path (`renderInputArea`) and the transient-prompt redraw (`RefreshTransient`), carrying correct right-edge handling:

- Skip clear-to-end-of-line when the rendered input sits in the pending-wrap state (it can erase the edge glyph).
- Force the pending wrap (`NewlineReturn`) before any later clear/cursor-movement sequences.

The transient path already appended its own `NewlineReturn`, and the old legacy `displayLine` also emitted one at the right edge, so the newline count in that path is unchanged.

## Testing

- Includes the PTY regression test from #112 (credited to @rztaylor). It **fails on master** (input wedges at the right edge, times out) and **passes** with this change.
- `go build`, `go vet`, and `go test ./...` all pass — full display suite (including transient/drift PTY tests) green, no regressions.

Supersedes #112.