### PR TITLE
fix(core): don't drop user input coalesced with the cursor-position answer

### DIFF
--- a/internal/core/keys_unix.go
+++ b/internal/core/keys_unix.go
@@ -61,22 +61,24 @@ func (k *Keys) GetCursorPos() (x, y int) {
 			return disable()
 		}
 
-		// Attempt to locate cursor response in it.
-		match = rxRcvCursorPos.FindAllStringSubmatch(string(cursor), 1)
+		// Split the chunk: the cursor answer out, everything else kept as
+		// user input. A single read can contain both — a line typed while
+		// the query was in flight coalesces with the response in the tty
+		// buffer — so the remainder must be preserved, not dropped.
+		cursorSeq, remain := k.extractCursorPos(cursor)
 
-		// If there is something but not cursor answer, its user input.
-		if len(match) == 0 && len(cursor) > 0 {
+		if len(remain) > 0 {
 			k.mutex.RLock()
-			k.buf = append(k.buf, cursor...)
+			k.buf = append(k.buf, remain...)
 			k.mutex.RUnlock()
+		}
 
+		// No cursor answer yet: keep reading.
+		if len(cursorSeq) == 0 {
 			continue
 		}
 
-		// And if empty, then we should abort.
-		if len(match) == 0 {
-			return disable()
-		}
+		match = rxRcvCursorPos.FindAllStringSubmatch(string(cursorSeq), 1)
 
 		break
 	}

--- a/internal/core/keys_unix_test.go
+++ b/internal/core/keys_unix_test.go
@@ -1,0 +1,47 @@
+//go:build unix
+
+package core
+
+import (
+	"os"
+	"testing"
+
+	"github.com/creack/pty"
+
+	"github.com/reeflective/readline/internal/term"
+)
+
+func TestGetCursorPosPreservesCoalescedInput(t *testing.T) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty: %v", err)
+	}
+	defer ptmx.Close()
+	defer tty.Close()
+
+	// Raw mode, as Readline always sets before the probe runs — in the
+	// slave's default canonical mode a read would block waiting for \n.
+	if _, err := term.MakeRaw(int(tty.Fd())); err != nil {
+		t.Fatalf("raw mode: %v", err)
+	}
+
+	origStdin := os.Stdin
+	os.Stdin = tty
+	defer func() { os.Stdin = origStdin }()
+
+	// The typed line and the cursor answer arrive as one chunk: written
+	// before the probe reads, they sit together in the tty input queue.
+	if _, err := ptmx.Write([]byte("echo hello\r\x1b[5;10R")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	keys := &Keys{}
+
+	x, y := keys.GetCursorPos()
+	if x != 10 || y != 5 {
+		t.Errorf("cursor position = (%d, %d), want (10, 5)", x, y)
+	}
+	if got := string(keys.buf); got != "echo hello\r" {
+		t.Errorf("pending input = %q, want %q (typed bytes must survive the probe)", got, "echo hello\r")
+	}
+}


### PR DESCRIPTION
`Keys.GetCursorPos` prints `ESC[6n` and, when the main key-reading routine is not active, reads stdin directly until it finds the terminal's `ESC[<row>;<col>R` answer.

If the user types (or pastes) while the query is in flight, the typed bytes and the answer sit together in the tty input queue
and come back in a single `read(2)`. This can cause the line to disappear. The main read path already handles this
correctly (`readInputFiltered` splits with `extractCursorPos` and passes the remainder on as keys); only the direct-read path inside `GetCursorPos` missed it.

The included test `TestGetCursorPosPreservesCoalescedInput` now passes with the fix.